### PR TITLE
System component ownership

### DIFF
--- a/polymorph/components.nim
+++ b/polymorph/components.nim
@@ -1,62 +1,5 @@
 import macros, typetraits, strformat, sharedtypes, private/utils, strutils
-
-type
-  EntityId* = distinct IdBaseType
-  EntityInstance* = distinct IdBaseType
-
-  EntityRef* = tuple[entityId: EntityId, instance: EntityInstance]
-  Entities* = seq[EntityRef]
-
-  Component* {.inheritable.} = ref object of RootObj
-    ## This root object allows runtime templates of components to be constructed.
-    ## `registerComponents` automatically generates a type descending from here for each component
-    ## type.
-    ## `typeId` has to match the valid componentTypeId for the type, and is automatically
-    ## initialised by called the generated ref init proc for the type (by default tmplTypeName()).
-    # Exposed fType id :( Required for currying parameters to ref inits and other set ups.
-    fTypeId*: ComponentTypeId
-
-  ## 'Generic' index into a component storage array.
-  ## This is 'sub-classed' into distinct types per component type by registerComponents.
-  ## These distinct versions of ComponentIndex allow direct access to component storage by
-  ## transforming the type at compile time to an index into the storage array that contains the
-  ## component.
-  ## For run-time operations on component ids, use `caseComponent` and pass the ComponentTypeId
-  ComponentIndex* = distinct int32
-  ## Instance count, incremented when the slot is used.
-  ## This is used to protect against referencing a deleted component with the same slot index.
-  ComponentGeneration* = distinct int32
-  ## Allows reference to particular instances of a component.
-  ## Component references are how indexes/keys to different components are stored, passed about, and fetched.
-  ## Not to be confused with the reference type `Component`.
-  ComponentRef* = tuple[typeId: ComponentTypeId, index: ComponentIndex, generation: ComponentGeneration]
-
-  ## Store a list of components, can be used as a template for constructing an entity.
-  ## `add` is overridden for this type to allow you to add user types or instance types
-  ## and their value is deepCopied into a ref container ready for `construct`.
-  ComponentList* = seq[Component]
-  ## A template for multiple entities
-  ConstructionTemplate* = seq[ComponentList]
-
-const
-  InvalidComponent* = 0.ComponentTypeId
-  InvalidComponentIndex* = 0.ComponentIndex
-  InvalidComponentInstance* = 0.ComponentGeneration
-  InvalidComponentGeneration* = 0.ComponentGeneration
-  InvalidComponentRef*: ComponentRef = (InvalidComponent, InvalidComponentIndex, InvalidComponentInstance)
-  
-  typeIdFieldName = "fTypeId"
-  ## An EntityId of zero indicates uninitialised data
-  NO_ENTITY* = 0.EntityId
-  ## Reference of an invalid entity
-  NO_ENTITY_REF*: EntityRef = (entityId: NO_ENTITY, instance: 0.EntityInstance)
-  # Max number of entities at once
-  # Note this is the maximum concurrent entity count, and
-  # defines the amount of memory allocated at start up.
-  FIRST_ENTITY_ID* = (NO_ENTITY.int + 1).EntityId
-  FIRST_COMPONENT_ID* = (InvalidComponentIndex.int + 1).ComponentIndex
-
-proc `==`*(s1, s2: SystemIndex): bool {.inline.} = s1.int == s2.int
+export macros
 
 macro componentNames*: untyped =
   ## Creates a runtime accessible array of typenames of all known components.
@@ -68,6 +11,7 @@ macro componentNames*: untyped =
 proc addComponentTypeId(typeNameStr: string): ComponentTypeId {.compileTime.} = 
   assert typeNameStr notin tNames, "Type name " & typeNameStr & " is already registered as a component"
   tNames.add(typeNameStr)
+  componentSystemOwner.add InvalidSystemIndex
   # add to runtime list to get component name from ComponentTypeId
   componentStrLits.add(newStrLitNode(typeNameStr))
   compTypeNodes.add(newIdentNode(typeNameStr))
@@ -77,7 +21,6 @@ proc addComponentTypeId(typeNameStr: string): ComponentTypeId {.compileTime.} =
 
 proc typeStringToId*(n: string): ComponentTypeId {.compiletime.} =
   ## Returns an index for a type string, if found.
-  ## Note this only checks entities that haven't been sealed yet.
   # TODO: String based checks of types with the same name will return the same ComponentTypeId.
   # Might want to store type trees themselves and match on that.
   assert(n != "Component", "Not enough type info to create id: Receiving type `Component`, expected sub-class of Component or a registered component type")
@@ -91,8 +34,6 @@ proc typeStringToId*(n: string): ComponentTypeId {.compiletime.} =
 
 ## Uses the typeId as an index into runtime component names
 proc toString*(id: ComponentTypeId): string = componentNames()[id.int]  
-
-proc `==`*(c1, c2: ComponentTypeId): bool = c1.int == c2.int
 
 ## Checks against invalid component (for example uninitialised data).
 ## This does not check to see if the component is alive in the system, only that it is semantically valid.
@@ -109,7 +50,7 @@ proc init*[T: Component](c: var T) {.inline.} =
 proc checkInit*[T: Component](c: var T) {.inline.} =
   if c.fTypeId == 0: c.fTypeId = c.type.typeId()
 
-macro makeRefCompInit(prefix: static[string], tyName: static[string], typeId: static[int]): untyped =
+proc makeRefCompInit(prefix: string, tyName: string, typeId: int): NimNode =
   # Generate init macro for reference type.
   # This macro curries the parameters to an object initialisation of the form `MyObjectRef(param1: value1, ...)`.
   let
@@ -118,6 +59,8 @@ macro makeRefCompInit(prefix: static[string], tyName: static[string], typeId: st
     initName = newIdentNode(initNameStr)
     initComment = newCommentStmtNode("Initialiser for " & tyNameRefStr & ", automatically sets `typeId` to " & $typeId)
     res = newIdentNode "result"
+    typeIdFieldName = "fTypeId"
+
   if refInitPrefixes.len <= typeId:
     refInitPrefixes.setLen(typeId + 1)
     refInitPrefixes[typeId] = prefix
@@ -143,7 +86,7 @@ macro makeRefCompInit(prefix: static[string], tyName: static[string], typeId: st
       stmts.add(nnkObjConstr.newTree(
         newIdentNode `tyNameRefStr`,
         nnkExprColonExpr.newTree(
-          newIdentNode(typeIdFieldName),
+          newIdentNode(`typeIdFieldName`),
           newDotExpr(newIntLitNode(`typeId`), newIdentNode("ComponentTypeId"))
         ),
         nnkExprColonExpr.newTree(
@@ -243,13 +186,10 @@ proc createRefComponent(typeNode: NimNode): NimNode =
 proc createRef(prefix: string, typeDef: NimNode, typeId: ComponentTypeId): NimNode =
   # Creates the ref type for this type and it's initialiser
   result = newStmtList()
-  result.add nnkTypeSection.newTree typeDef.createRefComponent
   # Create init proc using prefix and type name
   let typeName = $typeDef.nameNode()
-  result.add(quote do:
-    makeRefCompInit(`prefix`, `typeName`, `typeId`)
-  )
-
+  result.add makeRefCompInit(prefix, typeName, typeId.int)
+  
 proc doRegisterComponents(options: ECSCompOptions, body: NimNode): NimNode =
   ## Registers types in a block to tNames.
   ## For each type provided in `body`, this macro generates:
@@ -257,58 +197,48 @@ proc doRegisterComponents(options: ECSCompOptions, body: NimNode): NimNode =
   ##   * A static template to associate the type with a unique `ComponentTypeId`.
   ##   * An initialiser for use with runtime templates. This sets the type Id for you.
   ## The types sections you provide in `body` are passed through unaltered.
+
+  result = newStmtList()
+
   echo "=== Component generation options ===\n", options.repr
   if options.componentStorageFormat != cisSeq and options.maxComponents <= 0:
     error "Component option `maxComponents` must be greater than zero when using a non-resizable storage format"
 
-  let
-    maxComponentCount = options.maxComponents + 2
-    refInitPrefix = if options.refInitPrefix != "": options.refInitPrefix
-      else: defaultRefInitPrefix
-
-  result = newStmtList()
-
   var
     typeDeclarations = newStmtList()
     typeUtils = newStmtList()
-    # Each component gets a unique array generated in the storage type.
-    storageFields = nnkVarSection.newTree()
-
   let previousComponentsDeclared = tNames.len
 
-  # Go through all they nnkTypeDef nodes in body.
   for tyDef in body.typeDefs:
     let
       typeNameIdent = tyDef.nameNode()
       typeNameStr = $typeNameIdent
-      refTypeNameIdent = newIdentNode(refTypeName(typeNameStr))
       # store component type and generate id
       typeId = addComponentTypeId(typeNameStr)
+      instTypeNode = newIdentNode instanceTypeName(typeNameStr)
+      generationTypeNode = newIdentNode generationTypeName(typeNameStr)
+      typeIdAccessName = newIdentNode("typeId")
+      tyParam = newIdentNode("ty")
+      refTypeNameIdent = newIdentNode(refTypeName(typeNameStr))
+
+    ecsComponentsToBeSealed.add typeId
     
     # record the options for later transforms such as commitSystems
     ecsCompOptions.add(options)
 
-    let
-      typeIdAccessName = newIdentNode("typeId")
-      tyParam = newIdentNode("ty")
+    # Typefields is used in field templates.
+    componentFieldDefinitions.add tyDef.getFields(typeNameStr)
     
-    # Add distinct index type for this component type. This is used within the systems.
-    let
-      instTypeNode = newIdentNode instanceTypeName(typeNameStr)
-      instIdTypeNode = newIdentNode instanceIdTypeName(typeNameStr)
-    
-    # Add this type's instance type for use in generating a type class for all instances
-    instanceTypeNode.add instTypeNode
+    if componentDefinitions.high < typeId.int:
+      componentDefinitions.setLen typeId.int + 1
+    componentDefinitions[typeId.int] = tyDef
+
+    typeUtils.add nnkTypeSection.newTree tyDef.createRefComponent
 
     typeDeclarations.add(quote do:
       type `instTypeNode`* = distinct `IdBaseType`
-      type `instIdTypeNode`* = distinct `IdBaseType`
+      type `generationTypeNode`* = distinct `IdBaseType`
     )
-
-    # Add initialiser proc that sets `typeId` and passes on params to an object constructor.
-    # eg; initA*(): A = A(fTypeId: A.typeId)
-    typeUtils.add refInitPrefix.createRef(tyDef, typeId)
-
     # Add static transform to convert from type to `ComponentTypeId`
     # eg; template typeId*(ty: A | ARef | AInstance): ComponentTypeId = 1.ComponentTypeId
     # The same value is returned for a concrete instance, ref instance, and typedesc.
@@ -316,6 +246,52 @@ proc doRegisterComponents(options: ECSCompOptions, body: NimNode): NimNode =
       template `typeIdAccessName`*(`tyParam`: `typeNameIdent` | `refTypeNameIdent` | `instTypeNode` |
         typedesc[`typeNameIdent`] | typedesc[`refTypeNameIdent`] | typedesc[`instTypeNode`]): ComponentTypeId = `typeId`.ComponentTypeId
       )
+
+  if tNames.len == previousComponentsDeclared:
+    error "Cannot process registerComponents: No typedefs can be found to create components from"
+
+  # Generate the storage array type for these components
+  # storageTypeName: object =
+  #   <fields of type>
+  result.add typeDeclarations
+  # The body always gets added unchanged, but after the instance types have been generated.
+  # This allows instance types to be used within the user's type definitions.
+  result.add body
+  result.add typeUtils
+
+proc generateTypeStorage*(): NimNode =
+  result = newStmtList()
+
+  var
+    typeUtils = newStmtList()
+    # Each component gets a unique array generated in the storage type.
+    storageFields = nnkVarSection.newTree()
+
+  for typeId in ecsComponentsToBeSealed:
+    let
+      options = ecsCompOptions[typeId.int]
+      typeNameStr = tNames[typeId.int]
+      typeNameIdent = ident typeNameStr
+      refTypeNameIdent = newIdentNode(refTypeName(typeNameStr))
+      tyDef = componentDefinitions[typeId.int]
+      tyParam = newIdentNode("ty")
+
+      maxComponentCount = options.maxComponents + 2
+      refInitPrefix = if options.refInitPrefix != "": options.refInitPrefix
+        else: defaultRefInitPrefix
+
+    template typeFields: untyped = componentFieldDefinitions[typeId.int]
+    
+    doAssert typeFields.typeName == typeNameStr, "Internal error: Extracting type yielded " & typeFields.typeName & " but expected "  & typeNameStr
+
+    let instTypeNode = newIdentNode instanceTypeName(typeNameStr)
+    
+    # Add this type's instance type for use in generating a type class for all instances
+    instanceTypeNode.add instTypeNode
+
+    # Add initialiser proc that sets `typeId` and passes on params to an object constructor.
+    # eg; initA*(param = x): A = A(fTypeId: A.typeId, param: x)
+    typeUtils.add refInitPrefix.createRef(tyDef, typeId)
 
     typeUtils.add(quote do:
       ## Compile-time translation between a user's type/container type to it's instance type.
@@ -325,16 +301,11 @@ proc doRegisterComponents(options: ECSCompOptions, body: NimNode): NimNode =
       template containerType*(`tyParam`: typedesc[`typeNameIdent`] | typedesc[`instTypeNode`]): untyped = `refTypeNameIdent`
       ## Create a `ref` container from a user object. The parameter is deepCopied.
       template makeContainer*(`tyParam`: `typeNameIdent`): `refTypeNameIdent` =
-        var data: `typeNameIdent`
-        deepCopy(data, `tyParam`)
-        var container = `refTypeNameIdent`(fTypeId: `typeId`.ComponentTypeId, value: data)
+        var container = `refTypeNameIdent`(fTypeId: `typeId`.ComponentTypeId, value: `tyParam`)
         container
       ## Create a `ref` container from an instance. The parameter is deepCopied.
       template makeContainer*(`tyParam`: `instTypeNode`): `refTypeNameIdent` =
-        var data: `typeNameIdent`
-        deepCopy(data, `tyParam`.access)
-        var container = `refTypeNameIdent`(fTypeId: `typeId`.ComponentTypeId, value: data)
-        container
+        `tyParam`.access.makeContainer()
       )
 
     let storageFieldName = typeNameStr.storageFieldName
@@ -344,13 +315,24 @@ proc doRegisterComponents(options: ECSCompOptions, body: NimNode): NimNode =
         of cisArray: genArray(maxComps, typeIdent)
         of cisSeq: genSeq(typeIdent)
 
-    let useThreadVar = options.useThreadVar
+    let
+      useThreadVar = options.useThreadVar
+      ownerSystem = componentSystemOwner[typeId.int]
+      supportStorageSize =
+        if ownerSystem == InvalidSystemIndex:
+          maxComponentCount + 1
+        else:
+          let sysOpts = ecsSysOptions[ownerSystem.int]
+          if sysOpts.storageFormat == ssArray:
+            sysOpts.maxEntities + 1
+          else:
+            0
 
-    # Generate the array field that will hold this component within storage.
+    # Generate the field that will hold this component within storage.
     # eg; a: array[100000, A]
-    storageFields.add genField(storageFieldName, true, typeNameIdent.storageField(maxComponentCount), useThreadVar)
+    storageFields.add genField(storageFieldName, true, typeNameIdent.storageField(supportStorageSize), useThreadVar)
     
-    # Generate the last index array for this component of the specific instance type
+    # Generate the last index list for this component of the specific instance type
     # eg; aLastIndex: seq[AInstance]
     let freeIdxIdent = typeNameStr.freeInstancesName
     storageFields.add genField(freeIdxIdent, true, genSeq(instTypeNode), useThreadVar)
@@ -363,175 +345,23 @@ proc doRegisterComponents(options: ECSCompOptions, body: NimNode): NimNode =
     # Generate the instance alive state array for this component type
     # eg; aAlive: array[100000, bool]
     let aliveStateIdent = typeNameStr.aliveStateInstanceName
-    storageFields.add genField(aliveStateIdent, true, newIdentNode("bool").storageField(maxComponentCount), useThreadVar)
+    storageFields.add genField(aliveStateIdent, true, newIdentNode("bool").storageField(supportStorageSize), useThreadVar)
 
     # Generate an array of instance numbers against each component id
     # This allows us to compare an existing instance with a ComponentRef.
     let instanceIdsName = typeNameStr.instanceIdsName
-    storageFields.add genField(instanceIdsName, true, newIdentNode("int32").storageField(maxComponentCount), useThreadVar)
+    storageFields.add genField(instanceIdsName, true, newIdentNode("int32").storageField(supportStorageSize), useThreadVar)
 
-  if tNames.len == previousComponentsDeclared:
-    error "Cannot process registerComponents: No typedefs can be found to create components from"
-
-  # Generate the storage array type for these components
-  # storageTypeName: object =
-  #   <fields of type>
-  result.add typeDeclarations
-  # The body always gets added unchanged, but after the instance types have been generated.
-  # This allows instance types to be used within the user's type definitions.
-  result.add body
-  # Define the type for storing all component states.
   result.add storageFields
-
-  var firstCompIdInits = newStmtList()
-
-  # Now we do another pass to add templates that associate a type with it's storage variable
-  for tyDef in body.typeDefs:
-    let
-      # Type names
-      typeNameIdent = tyDef.nameNode()                          # Type itself
-      typeNameStr = $typeNameIdent                              # Name as string
-      typeId = typeStringToId(typeNameStr)                      # Type's unique typeId
-      refTypeNameIdent = newIdentNode refTypeName(typeNameStr)  # Ref container type
-      instTypeName = instanceTypeName(typeNameStr)
-      instTypeNode = newIdentNode instTypeName                  # Type's instance type
-      instanceIds = newIdentNode instanceIdsName(typeNameStr)   # Type's instance id array
-      instIdType = newIdentNode instanceIdTypeName(typeNameStr) # Unique type for this type's instance id
-      # Variable names
-      storageFieldName = storageFieldName(typeNameStr)
-      lcTypeIdent = newIdentNode storageFieldName
-      instanceTypeIdent = newIdentNode instanceTypeName(typeNameStr)
-      aliveIdent = newIdentNode aliveStateInstanceName(typeNameStr)
-      nextIdxIdent = newIdentNode nextInstanceName(typeNameStr)
-      res = ident "result"
-      
-      # Parameter names
-      tyParam = ident "ty"
-
-    ecsComponentsToBeSealed.add typeId
-
-    # Extra init for heap items
-    case options.componentStorageFormat
-      of cisArray: discard
-      of cisSeq:
-        firstCompIdInits.add(quote do:
-          `lcTypeIdent` = newSeq[`typeNameIdent`](1)
-          `aliveIdent` = newSeq[bool](1)
-          `instanceIds` = newSeq[int32](1)
-        )
-    # Ensure first component item is valid.
-    firstCompIdInits.add(quote do:
-      `nextIdxIdent` = FIRST_COMPONENT_ID.`instanceTypeIdent`
-    )
-
-    # Add a translation from the type of the component to the base storage array for it's data.
-    # This allows ComponentIndex.storage[some_index] to refer to other components of the same type.
-    typeUtils.add(quote do:
-      template storage*(`tyParam`: typedesc[`typeNameIdent`] | typedesc[`refTypeNameIdent`]): untyped = `lcTypeIdent`
-      )
-
-    let
-      eqOp = nnkAccQuoted.newTree(newIdentNode "==")
-      strOp = nnkAccQuoted.newTree(ident "$")
-      deletedComp = newLit "<Deleted " & instTypeName # Completed below.
-      invalidStr = newLit "<Invalid " & instTypeName & ">"
-
-    # Add direct lookup of the instance identifier to the component data,
-    # and allow access of the fields directly from the instance.
-    typeUtils.add(quote do:
-      ## Converts the instance to a component storage directly.
-      template access*(instance: `instanceTypeIdent`): `typeNameIdent` = `lcTypeIdent`[instance.int]
-      template `eqOp`*(i1, i2: `instanceTypeIdent`): bool = i1.int == i2.int
-      template alive*(inst: `instTypeNode`): bool =
-        ## Check if this component ref's index is still valid.
-        `aliveIdent`[inst.int] == true
-      template valid*(inst: `instanceTypeIdent`): bool = inst.int != InvalidComponentIndex.int and inst.alive
-
-      template generation*(inst: `instTypeNode`): untyped =
-        ## Access the generation of this component.
-        `instIdType`(`instanceIds`[inst.int])
-
-      template toRef*(inst: `instTypeNode`): ComponentRef =
-        ## Utility function that takes this type's distinct `ComponentIndex`,
-        ## returned for example from fetchComponent, and creates a reference
-        ## tuple for the live component currently at this index.
-        (inst.typeId, inst.ComponentIndex, inst.generation.ComponentGeneration)
-
-      proc `strOp`*(val: `instanceTypeIdent`): string =
-        if val.valid:
-          try:
-            `res` = val.access.repr
-          except:
-            `res` = "<Error accessing>"
-        else:
-          if val.int == InvalidComponentIndex.int:
-            `res` = `invalidStr`
-          else:
-            `res` = `deletedComp` & " (index: " & $val.int & ")>"
-    )
-
-    # The user can choose whether they want to use dot operators or generate access templates for each field.
-    # Dot operators:
-    #   * Pros: Tend to work seamlessly with other templates and overloading resolution.
-    #   * Cons: Can get confused when chaining long sequences together (in which case, use `access`).
-    # Templates:
-    #   * Pros: In theory better direct replacement of statements so more able to chain without issue.
-    #   * Cons: In reality, variables with the same name as a template field can fail as ambiguous.
-    #   * We can replace templates with procs, but now we the overhead of new stack frames for each access (though
-    #     expect compiler to inline), and may also change semantics to copy instead of access.
-
-    # Typefields is used in field templates.
-    let typeFields = tyDef.getFields(typeNameStr)
-
-    # Access the fields of the component in storage via the index.
-    # Two approaches, via dot operators or building access templates for every field in this component (not recursive).
-    let
-      inst = ident "instance"
-      fieldParam = ident "field"
-      valueParam = ident "value"
-    case options.accessMethod
-    of amDotOp:
-      # We only need two dot operators, one for reading and one for writing to cover all the fields in this instance.
-      {.push experimental: "dotOperators".}
-      let
-        dotOp = nnkAccQuoted.newTree(newIdentNode ".")
-        dotEqOp = nnkAccQuoted.newTree(newIdentNode ".=")
-      typeUtils.add(quote do:
-        template `dotOp`*(`inst`: `instanceTypeIdent`, `fieldParam`: untyped): untyped =
-          when compiles(`lcTypeIdent`[`inst`.int].`fieldParam`):
-            `lcTypeIdent`[`inst`.int].`fieldParam`
-          else:
-            {.fatal: "Cannot find field `" & `fieldParam`.repr & "` in instance type " & `typeNameStr`.}
-            discard
-        template `dotEqOp`*(`inst`: `instanceTypeIdent`, `fieldParam`: untyped, `valueParam`: untyped): untyped =
-          when compiles(`lcTypeIdent`[`inst`.int].`fieldParam`):
-            `lcTypeIdent`[`inst`.int].`fieldParam` = `valueParam`
-          else:
-            {.fatal: "Cannot find field `" & `fieldParam`.repr & "` in instance type " & `typeNameStr`.}
-            discard
-      )
-      {.pop.}
-    of amFieldTemplates:
-      # Generate read/write access template from the type's typeDef.
-      doAssert typeFields.len == 1, "Internal error: Expected one result for " & typeNameStr & " when extracting fields"
-      doAssert typeFields[0].typeName == typeNameStr, "Internal error: Extracting type yielded " & typeFields[0].typeName & " but expected "  & typeNameStr
-
-      for field in typeFields[0].fields:
-        let
-          fieldName = field.fieldNode
-          fieldType = field.typeNode
-          setField = nnkAccQuoted.newTree(ident $fieldName & "=")
-        typeUtils.add(quote do:
-          template `fieldName`*(`inst`: `instanceTypeIdent`): `fieldType` = `lcTypeIdent`[instance.int].`fieldName`
-          template `setField`*(`inst`: `instanceTypeIdent`, `valueParam`: `fieldType`): untyped = `lcTypeIdent`[instance.int].`fieldName` = `valueParam`
-        )
-  result.add firstCompIdInits
   result.add typeUtils
+  genLog "# Component storage:\n", result.repr
 
 proc genTypeAccess*(): NimNode =
-  ## This is invoked within makeEcs.
   result = newStmtList()  
-  var typeAccess = newStmtList()
+  
+  var
+    typeAccess = newStmtList()
+    firstCompIdInits = newStmtList()
 
   for typeId in ecsComponentsToBeSealed:
     let
@@ -552,122 +382,36 @@ proc genTypeAccess*(): NimNode =
       aliveIdent = newIdentNode aliveStateInstanceName(typeNameStr)
       nextIdxIdent = newIdentNode nextInstanceName(typeNameStr)
       tyParam = ident "ty"
-      valueParam = ident "updateWith"
+      instTypeName = instanceTypeName(typeNameStr)
+      instTypeNode = newIdentNode instTypeName                  # Type's instance type
+      generationTypeNode = newIdentNode generationTypeName(typeNameStr)
+      res = ident "result"
+    template typeFields: untyped = componentFieldDefinitions[typeId.int]
 
     # Add a proc to return a new component index.
     # This is the 'new component' procedure, and uses the `initPrefix` parameters.
     typeAccess.add(makeInstanceCompInit(initPrefix, typeNameStr, typeId.int))
     
-    proc accessOp(id, op: NimNode): NimNode =
-      case options.componentStorageFormat
-      of cisArray, cisSeq:
-        quote do: `id`.`op`
-
-    let
-      # delIdx is the index of the component in it's storage.
-      delIdx = ident "idx"
-      storageHigh = accessOp(lcTypeIdent, ident "high")
-      freeIdxLen = quote do: `freeIdxIdent`.len
-      freeIdxPop = quote do: `freeIdxIdent`.pop
-
-    # This is expected to return the typed index for the new component.
-    let handleNextStorageItem =
-      case options.componentStorageFormat
-      of cisArray:
-        quote do:
-          let cur = `nextIdxIdent`
-          assert `nextIdxIdent`.int < `maxComponentCount`, "Ran out of space to store this component (max slot index: " &
-            $(`maxComponentCount` - 1) & ", asked for " & $(`nextIdxIdent`.int) & ")"
-          `nextIdxIdent` = (`nextIdxIdent`.int + 1).`instanceTypeIdent`
-          cur
+    # Potentially extra init for heap items
+    case options.componentStorageFormat
+      of cisArray: discard
       of cisSeq:
-        quote do:
-          let newLen = `lcTypeIdent`.len + 1
-          `lcTypeIdent`.setLen(newLen)
-          `instanceIds`.setLen(newLen)
-          `aliveIdent`.setLen(newLen)
-          `lcTypeIdent`.high.`instanceTypeIdent`
+        firstCompIdInits.add(quote do:
+          `lcTypeIdent` = newSeq[`typeNameIdent`](1)
+          `aliveIdent` = newSeq[bool](1)
+          `instanceIds` = newSeq[int32](1)
+        )
 
-    # Remove `delIdx` from the component array.
-    let handleDelStorageItem =
-      case options.componentStorageFormat
-      of cisArray:
-        quote do:
-          # We need to subtract the length by one because the first item starts at one.
-          if `freeIdxIdent`.len == `storageHigh` - 1:
-            # If the free list is full, everything's free so we can reset the list.
-            `freeIdxIdent`.setLen 0
-          else:
-            `freeIdxIdent`.add `delIdx`.`instanceTypeIdent`
-      of cisSeq:
-        quote do:
-          # We don't need nextIdxIdent as this is naturally managed by seq.len
-          if `freeIdxIdent`.high == `lcTypeIdent`.high:
-            # Shrink seqs and update next index var.
-            # We need to reserve index zero for invalid component.
-            # The free list is full, everything is free so we can reset the list.
-            `freeIdxIdent`.setLen(0)
-          if `delIdx` == `lcTypeIdent`.high:
-            let newLen = max(1, `lcTypeIdent`.len - 1)
-            `lcTypeIdent`.setLen(newLen)
-            `instanceIds`.setLen(newLen)
-            `aliveIdent`.setLen(newLen)
-          else:
-            # Add to free indexes.
-            `freeIdxIdent`.add `delIdx`.`instanceTypeIdent`
+    # Ensure first component item is valid.
+    firstCompIdInits.add(quote do:
+      `nextIdxIdent` = FIRST_COMPONENT_ID.`instanceTypeIdent`
+    )
 
     let
-      componentLen =
-        case options.componentStorageFormat
-        of cisArray:
-          quote do:
-            `nextIdxIdent`.int - 1
-        of cisSeq:
-          quote do:
-            `lcTypeIdent`.len
-
-    let
-      res = ident "result"
-      clearOnDelete =
-        if options.clearAfterDelete:
-          quote do:
-            zeroMem(`instParam`.access.addr, `typeNameIdent`.sizeOf)
-        else:
-          newEmptyNode()
-      userInitCode =
-        if typeId.int < componentInitialisationCode.len and
-          componentInitialisationCode[typeId.int] != nil:
-            let code = componentInitialisationCode[typeId.int]
-            quote do:
-              block:
-                template curComponent: `instanceTypeIdent` = `res`
-                `code`
-        else:
-          newEmptyNode()
-      userFinalCode =
-        if typeId.int < componentFinalisationCode.len and
-          componentFinalisationCode[typeId.int] != nil:
-            componentFinalisationCode[typeId.int]
-        else:
-          newEmptyNode()
-      
-      rawCreate = quote do:
-        var r: `instanceTypeIdent`
-        if `freeIdxLen` > 0:
-          # Use last spare index.
-          r = `freeIdxPop`
-        else:
-          # Generate a new index.
-          r = `handleNextStorageItem`
-        assert r.int != 0
-        # Update alive state.
-        `aliveIdent`[r.int] = true
-        # Update instance state.
-        # This means the first valid index will start at one,
-        # and an instance of zero can be used as an invalid state (see InvalidComponentRef)
-        `instanceIds`[r.int] += 1
-        r
-
+      eqOp = nnkAccQuoted.newTree(newIdentNode "==")
+      strOp = nnkAccQuoted.newTree(ident "$")
+      deletedComp = newLit "<Deleted " & instTypeName # Completed below.
+      invalidStr = newLit "<Invalid " & instTypeName & ">"
       userUpdateCode =
         if typeId.int < componentInterceptValueInitCode.len and
           componentInterceptValueInitCode[typeId.int] != nil:
@@ -677,87 +421,362 @@ proc genTypeAccess*(): NimNode =
           newEmptyNode()
       
       commitParam = ident "newValue"
+      valueParam = ident "value"
+      inst = ident "instance"
+      fieldParam = ident "field"
     
-      standAloneUpdate =
-        if userUpdateCode.kind != nnkEmpty:
+    if componentSystemOwner[typeId.int] != InvalidSystemIndex:
+      let
+        ownerSystemIdx = componentSystemOwner[typeId.int]
+        ownerSystem = allSystemsNode[ownerSystemIdx.int]
+        sysTupleFieldStr = typeNameStr.toLowerAscii
+        sysTupleField = ident sysTupleFieldStr
+        standAloneUpdate =
+          if userUpdateCode.kind != nnkEmpty:
+            quote do:
+              template commit(`commitParam`: `typeNameIdent`): untyped {.used.} =         
+                `ownerSystem`.groups[`inst`.int].`sysTupleField` = `commitParam`
+              template curValue: `typeNameIdent` = `valueParam`
+              `userUpdateCode`
+          else:
+            quote do:
+              `ownerSystem`.groups[`inst`.int].`sysTupleField` = `valueParam`
+
+      # Access the fields of the component in storage via the index.
+      # Two approaches, via dot operators or building access templates for every field in this component (not recursive).
+      case options.accessMethod
+      of amDotOp:
+        # We only need two dot operators, one for reading and one for writing to cover all the fields in this instance.
+        {.push experimental: "dotOperators".}
+        let
+          dotOp = nnkAccQuoted.newTree(newIdentNode ".")
+          dotEqOp = nnkAccQuoted.newTree(newIdentNode ".=")
+        typeAccess.add(quote do:
+          template `dotOp`*(`inst`: `instanceTypeIdent`, `fieldParam`: untyped): untyped =
+            when compiles(`ownerSystem`.groups[`inst`.int].`sysTupleField`.`fieldParam`):
+              `ownerSystem`.groups[`inst`.int].`sysTupleField`.`fieldParam`
+            else:
+              {.fatal: "Cannot find field `" & `fieldParam`.repr & "` in instance type " & `typeNameStr`.}
+              discard
+          template `dotEqOp`*(`inst`: `instanceTypeIdent`, `fieldParam`: untyped, `valueParam`: untyped): untyped =
+            when compiles(`ownerSystem`.groups[`inst`.int].`sysTupleField`.`fieldParam`):
+              `ownerSystem`.groups[`inst`.int].`sysTupleField`.`fieldParam` = `valueParam`
+            else:
+              {.fatal: "Cannot find field `" & `fieldParam`.repr & "` in instance type " & `typeNameStr`.}
+              discard
+        )
+        {.pop.}
+      of amFieldTemplates:
+        # Generate read/write access template from the type's typeDef.
+
+        for field in typeFields.fields:
+          let
+            fieldName = field.fieldNode
+            fieldType = field.typeNode
+            setField = nnkAccQuoted.newTree(ident $fieldName & "=")
+          typeAccess.add(quote do:
+            template `fieldName`*(`inst`: `instanceTypeIdent`): `fieldType` = `ownerSystem`.groups[`inst`.int].`fieldName`
+            template `setField`*(`inst`: `instanceTypeIdent`, `valueParam`: `fieldType`): untyped = `ownerSystem`.groups[`inst`.int].`fieldName` = `valueParam`
+          )
+
+      typeAccess.add(quote do:
+        template ownedComponent*(value: typedesc[`instanceTypeIdent`] | `instanceTypeIdent` | `typeNameIdent`): bool = true
+        template valid*(`inst`: `instanceTypeIdent`): bool =
+          # TODO: Check generation.
+          `inst`.int >= 0 and `inst`.int < `ownerSystem`.groups.len
+        ## Converts the instance to a component storage directly.
+        template access*(`inst`: `instanceTypeIdent`): `typeNameIdent` = `ownerSystem`.groups[`inst`.int].`sysTupleField`
+        template alive*(inst: `instTypeNode`): bool =
+          ## Check if this component ref's index is still valid.
+          `aliveIdent`[inst.int] == true
+        template generation*(inst: `instTypeNode`): untyped =
+          ## Access the generation of this component.
+          `generationTypeNode`(`instanceIds`[inst.int]).ComponentGeneration
+        template `createIdent`: untyped = discard
+        proc `deleteIdent`*(`instParam`: `instanceTypeIdent`) = discard
+        ## Updating storage.
+        ## `update` operates as a simple assignment into the storage array and therefore operates on the type's `==` proc.
+        template update*(`instParam`: `instanceTypeIdent`, `valueParam`: `typeNameIdent`): untyped =
+          `standAloneUpdate`
+      )
+
+    else:
+
+      let
+        standAloneUpdate =
+          if userUpdateCode.kind != nnkEmpty:
+            quote do:
+              template commit(`commitParam`: `typeNameIdent`): untyped {.used.} =         
+                `lcTypeIdent`[`instParam`.int] = `commitParam`
+              template curValue: `typeNameIdent` = `valueParam`
+              `userUpdateCode`
+          else:
+            quote do:
+              `lcTypeIdent`[`instParam`.int] = `valueParam`
+
+      # Add a translation from the type of the component to the base storage array for it's data.
+      # This allows ComponentIndex.storage[some_index] to refer to other components of the same type.
+      typeAccess.add(quote do:
+        template storage*(`tyParam`: typedesc[`typeNameIdent`] | typedesc[`refTypeNameIdent`]): untyped = `lcTypeIdent`
+        )
+
+      # The user can choose whether they want to use dot operators or generate access templates for each field.
+      # Dot operators:
+      #   * Pros: Tend to work seamlessly with other templates and overloading resolution.
+      #   * Cons: Can get confused when chaining long sequences together (in which case, use `access`).
+      # Templates:
+      #   * Pros: In theory better direct replacement of statements so more able to chain without issue.
+      #   * Cons: In reality, variables with the same name as a template field can fail as ambiguous.
+      #   * We can replace templates with procs, but now we the overhead of new stack frames for each access (though
+      #     expect compiler to inline), and may also change semantics to copy instead of access.
+
+      # Access the fields of the component in storage via the index.
+      # Two approaches, via dot operators or building access templates for every field in this component (not recursive).
+      case options.accessMethod
+      of amDotOp:
+        # We only need two dot operators, one for reading and one for writing to cover all the fields in this instance.
+        {.push experimental: "dotOperators".}
+        let
+          dotOp = nnkAccQuoted.newTree(newIdentNode ".")
+          dotEqOp = nnkAccQuoted.newTree(newIdentNode ".=")
+        typeAccess.add(quote do:
+          template `dotOp`*(`inst`: `instanceTypeIdent`, `fieldParam`: untyped): untyped =
+            when compiles(`lcTypeIdent`[`inst`.int].`fieldParam`):
+              `lcTypeIdent`[`inst`.int].`fieldParam`
+            else:
+              {.fatal: "Cannot find field `" & `fieldParam`.repr & "` in instance type " & `typeNameStr`.}
+              discard
+          template `dotEqOp`*(`inst`: `instanceTypeIdent`, `fieldParam`: untyped, `valueParam`: untyped): untyped =
+            when compiles(`lcTypeIdent`[`inst`.int].`fieldParam`):
+              `lcTypeIdent`[`inst`.int].`fieldParam` = `valueParam`
+            else:
+              {.fatal: "Cannot find field `" & `fieldParam`.repr & "` in instance type " & `typeNameStr`.}
+              discard
+        )
+        {.pop.}
+      of amFieldTemplates:
+        # Generate read/write access template from the type's typeDef.
+        doAssert typeFields.typeName == typeNameStr, "Internal error: Extracting type yielded " & typeFields.typeName & " but expected "  & typeNameStr
+
+        for field in typeFields.fields:
+          let
+            fieldName = field.fieldNode
+            fieldType = field.typeNode
+            setField = nnkAccQuoted.newTree(ident $fieldName & "=")
+          typeAccess.add(quote do:
+            template `fieldName`*(`inst`: `instanceTypeIdent`): `fieldType` = `lcTypeIdent`[instance.int].`fieldName`
+            template `setField`*(`inst`: `instanceTypeIdent`, `valueParam`: `fieldType`): untyped = `lcTypeIdent`[instance.int].`fieldName` = `valueParam`
+          )
+
+      typeAccess.add(quote do:
+        ## Conve2rts the instance to a component storage directly.
+        template ownedComponent*(value: typedesc[`instanceTypeIdent`] | `instanceTypeIdent` | `typeNameIdent`): bool = false
+        template access*(instance: `instanceTypeIdent`): `typeNameIdent` = `lcTypeIdent`[instance.int]
+        template alive*(inst: `instTypeNode`): bool =
+          ## Check if this component ref's index is still valid.
+          `aliveIdent`[inst.int] == true
+        template valid*(inst: `instanceTypeIdent`): bool = inst.int != InvalidComponentIndex.int and inst.alive
+        template generation*(inst: `instTypeNode`): untyped =
+          ## Access the generation of this component.
+          `generationTypeNode`(`instanceIds`[inst.int]).ComponentGeneration
+      )
+
+      let
+        # delIdx is the index of the component in it's storage.
+        delIdx = ident "idx"
+        storageHigh = newDotExpr(lcTypeIdent, ident "high")
+        freeIdxLen = quote do: `freeIdxIdent`.len
+        freeIdxPop = quote do: `freeIdxIdent`.pop
+
+      # This is expected to return the typed index for the new component.
+      let handleNextStorageItem =
+        case options.componentStorageFormat
+        of cisArray:
           quote do:
-            template commit(`commitParam`: `typeNameIdent`): untyped {.used.} =         
-              `lcTypeIdent`[`instParam`.int] = `commitParam`
-            template curValue: `typeNameIdent` = `valueParam`
-            `userUpdateCode`
-        else:
+            let cur = `nextIdxIdent`
+            assert `nextIdxIdent`.int < `maxComponentCount`, "Ran out of space to store this component (max slot index: " &
+              $(`maxComponentCount` - 1) & ", asked for " & $(`nextIdxIdent`.int) & ")"
+            `nextIdxIdent` = (`nextIdxIdent`.int + 1).`instanceTypeIdent`
+            cur
+        of cisSeq:
           quote do:
-            `lcTypeIdent`[`instParam`.int] = `valueParam`
-      newCompUpdate =
-        if userUpdateCode.kind != nnkEmpty:
+            let newLen = `lcTypeIdent`.len + 1
+            `lcTypeIdent`.setLen(newLen)
+            `instanceIds`.setLen(newLen)
+            `aliveIdent`.setLen(newLen)
+            `lcTypeIdent`.high.`instanceTypeIdent`
+
+      # Remove `delIdx` from the component array.
+      let handleDelStorageItem =
+        case options.componentStorageFormat
+        of cisArray:
           quote do:
-            template commit(`commitParam`: `typeNameIdent`): untyped {.used.} =         
-              `lcTypeIdent`[`res`.int] = `commitParam`
-            template curValue: `typeNameIdent` = `valueParam`
-            `userUpdateCode`
-        else:
+            # We need to subtract the length by one because the first item starts at one.
+            if `freeIdxIdent`.len == `storageHigh` - 1:
+              # If the free list is full, everything's free so we can reset the list.
+              `freeIdxIdent`.setLen 0
+            else:
+              `freeIdxIdent`.add `delIdx`.`instanceTypeIdent`
+        of cisSeq:
           quote do:
-            `lcTypeIdent`[`res`.int] = `valueParam`
+            # We don't need nextIdxIdent as this is naturally managed by seq.len
+            if `freeIdxIdent`.high == `lcTypeIdent`.high:
+              # Shrink seqs and update next index var.
+              # We need to reserve index zero for invalid component.
+              # The free list is full, everything is free so we can reset the list.
+              `freeIdxIdent`.setLen(0)
+            if `delIdx` == `lcTypeIdent`.high:
+              let newLen = max(1, `lcTypeIdent`.len - 1)
+              `lcTypeIdent`.setLen(newLen)
+              `instanceIds`.setLen(newLen)
+              `aliveIdent`.setLen(newLen)
+            else:
+              # Add to free indexes.
+              `freeIdxIdent`.add `delIdx`.`instanceTypeIdent`
+
+      let
+        componentLen =
+          case options.componentStorageFormat
+          of cisArray:
+            quote do:
+              `nextIdxIdent`.int - 1
+          of cisSeq:
+            quote do:
+              `lcTypeIdent`.len
+
+      let
+        res = ident "result"
+        clearOnDelete =
+          if options.clearAfterDelete:
+            quote do:
+              zeroMem(`instParam`.access.addr, `typeNameIdent`.sizeOf)
+          else:
+            newEmptyNode()
+        userInitCode =
+          if typeId.int < componentInitialisationCode.len and
+            componentInitialisationCode[typeId.int] != nil:
+              let code = componentInitialisationCode[typeId.int]
+              quote do:
+                block:
+                  template curComponent: `instanceTypeIdent` = `res`
+                  `code`
+          else:
+            newEmptyNode()
+        userFinalCode =
+          if typeId.int < componentFinalisationCode.len and
+            componentFinalisationCode[typeId.int] != nil:
+              componentFinalisationCode[typeId.int]
+          else:
+            newEmptyNode()
+        
+        rawCreate = quote do:
+          var r: `instanceTypeIdent`
+          if `freeIdxLen` > 0:
+            # Use last spare index.
+            r = `freeIdxPop`
+          else:
+            # Generate a new index.
+            r = `handleNextStorageItem`
+          assert r.int != 0
+          # Update alive state.
+          `aliveIdent`[r.int] = true
+          # Update instance state.
+          # This means the first valid index will start at one,
+          # and an instance of zero can be used as an invalid state (see InvalidComponentRef)
+          `instanceIds`[r.int] += 1
+          r
+
+        newCompUpdate =
+          if userUpdateCode.kind != nnkEmpty:
+            quote do:
+              template commit(`commitParam`: `typeNameIdent`): untyped {.used.} =         
+                `lcTypeIdent`[`res`.int] = `commitParam`
+              template curValue: `typeNameIdent` = `valueParam`
+              `userUpdateCode`
+          else:
+            quote do:
+              `lcTypeIdent`[`res`.int] = `valueParam`
+
+      typeAccess.add(quote do:
+        proc `createIdent`*: `instanceTypeIdent` =
+          ## Create a component instance for this type.
+          # This proc is generated for each type to use the separate storage locations.
+          # This involves either popping an index from the component's free list or incrementing it's next value counter,
+          # then setting it's alive index to true.
+          `res` = `rawCreate`
+          `userInitCode`
+        proc `deleteIdent`*(`instParam`: `instanceTypeIdent`) =
+          ## Free a component instance
+          let `delIdx` = `instParam`.int
+          assert `delIdx` < `aliveIdent`.len, "Cannot delete, instance is out of range"
+          if `aliveIdent`[`delIdx`]:
+            `userFinalCode`
+            # Only add something to the delete list if it's still alive, duplicate items would means all kinds of chaos.
+            `aliveIdent`[`delIdx`] = false
+            # Let delete know this index is now free.
+
+            # TODO: With many items being deleted rapidly, the seq behind this will suffer much memory allocation and data moving.
+            `handleDelStorageItem`
+            # Clear the memory for this type.
+            `clearOnDelete`
+        ## Create a new component instance. Does not update systems.
+        template newInstance*(`tyParam`: typedesc[`typeNameIdent`] | typedesc[`instanceTypeIdent`]): `instanceTypeIdent` = `createIdent`()
+        ## Create a new component instance from the supplied value. Does not update systems.
+        proc newInstance*(`valueParam`: `typeNameIdent`): `instanceTypeIdent` {.inline.} =
+          `res` = `rawCreate`
+          `userInitCode`
+          `newCompUpdate`
+        ## Creates a new component from a generated `ref` component descendant. Does not update systems.
+        template newInstance*(`tyParam`: typedesc[`typeNameIdent`] | typedesc[`instanceTypeIdent`], val: Component): untyped =
+          newInstance(`refTypeNameIdent`(val).value)
+        ## Marks a component as deleted. Does not update systems.
+        template delInstance*(`tyParam`: `typeNameIdent` | `instanceTypeIdent`): untyped = `tyParam`.`deleteIdent`()
+
+        # TODO: Add possibility to merge updates, so that only fields you mention change, the rest remain untouched.
+        # This is as opposed to the current update which replaces the whole contents of the variable with the new one.
+        # Potential name: `edit`.
+        # myComp.edit:
+        #   field1 = value1
+        #   field2 = value2
+
+        ## Updating storage.
+        ## `update` operates as a simple assignment into the storage array and therefore operates on the type's `==` proc.
+        template update*(`instParam`: `instanceTypeIdent`, `valueParam`: `typeNameIdent`): untyped =
+          #template curComponent: `instanceTypeIdent` = `instParam`
+          `standAloneUpdate`
+
+        template componentCount*(`tyParam`: typedesc[`typeNameIdent`] | typedesc[`instanceTypeIdent`]): untyped =
+          ## Returns an estimate of the number of allocated components.
+          ## This value is based on last index used and the number of indexes waiting to be used (from previous deletes).
+          # Value zero is invalid, so we subtract the index by one.
+          let freeCount = `freeIdxIdent`.len
+          `componentLen` - freeCount
+      )
 
     typeAccess.add(quote do:
-      proc `createIdent`*: `instanceTypeIdent` =
-        ## Create a component instance for this type.
-        # This proc is generated for each type to use the separate storage locations.
-        # This involves either popping an index from the component's free list or incrementing it's next value counter,
-        # then setting it's alive index to true.
-        `res` = `rawCreate`
-        `userInitCode`
+      template `eqOp`*(i1, i2: `instanceTypeIdent`): bool = i1.int == i2.int
 
-      proc `deleteIdent`*(`instParam`: `instanceTypeIdent`) =
-        ## Free a component instance
-        let `delIdx` = `instParam`.int
-        assert `delIdx` < `aliveIdent`.len, "Instance is out of range"
-        if `aliveIdent`[`delIdx`]:
-          `userFinalCode`
-          # Only add something to the delete list if it's still alive, duplicate items would means all kinds of chaos.
-          `aliveIdent`[`delIdx`] = false
-          # Let delete know this index is now free.
+      template toRef*(inst: `instTypeNode`): ComponentRef =
+        ## Utility function that takes this type's distinct `ComponentIndex`,
+        ## returned for example from fetchComponent, and creates a reference
+        ## tuple for the live component currently at this index.
+        (inst.typeId, inst.ComponentIndex, inst.generation)
 
-          # TODO: With many items being deleted rapidly, the seq behind this will suffer much memory allocation and data moving.
-          `handleDelStorageItem`
-          # Clear the memory for this type.
-          `clearOnDelete`
+      proc `strOp`*(val: `instanceTypeIdent`): string =
+        if val.valid:
+          try:
+            `res` = val.access.repr
+          except:
+            `res` = "<Error accessing>\n"
+        else:
+          if val.int == InvalidComponentIndex.int:
+            `res` = `invalidStr`
+          else:
+            `res` = `deletedComp` & " (index: " & $val.int & ")>"
+      )
 
-      ## Create a new component instance. Does not update systems.
-      template newInstance*(`tyParam`: typedesc[`typeNameIdent`] | typedesc[`instanceTypeIdent`]): `instanceTypeIdent` = `createIdent`()
-
-      # TODO: Add possibility to merge updates, so that only fields you mention change, the rest remain untouched.
-      # This is as opposed to the current update which replaces the whole contents of the variable with the new one.
-      # Potential name: `edit`.
-
-      ## Updating storage.
-      ## `update` operates as a simple assignment into the storage array and therefore operates on the type's `==` proc.
-      template update*(`instParam`: `instanceTypeIdent`, `valueParam`: `typeNameIdent`): untyped =
-        #template curComponent: `instanceTypeIdent` = `instParam`
-        `standAloneUpdate`
-
-      ## Create a new component instance from the supplied value. Does not update systems.
-      proc newInstance*(`valueParam`: `typeNameIdent`): `instanceTypeIdent` {.inline.} =
-        #template curComponent: `instanceTypeIdent` = `res`
-        `res` = `rawCreate`
-        `userInitCode`
-        `newCompUpdate`
-        
-      ## Creates a new component from a generated `ref` component descendant. Does not update systems.
-      template newInstance*(`tyParam`: typedesc[`typeNameIdent`] | typedesc[`instanceTypeIdent`], val: Component): untyped =
-        newInstance(`refTypeNameIdent`(val).value)
-      ## Marks a component as deleted. Does not update systems.
-      template delInstance*(`tyParam`: `typeNameIdent` | `instanceTypeIdent`): untyped = `tyParam`.`deleteIdent`()
-
-      template componentCount*(`tyParam`: typedesc[`typeNameIdent`] | typedesc[`instanceTypeIdent`]): untyped =
-        ## Returns an estimate of the number of allocated components.
-        ## This value is based on last index used and the number of indexes waiting to be used (from previous deletes).
-        # Value zero is invalid, so we subtract the index by one.
-        let freeCount = `freeIdxIdent`.len
-        `componentLen` - freeCount
-    )
-
-  result.add(typeAccess)
+  result.add typeAccess
+  result.add firstCompIdInits
 
   # Add a generated type class that covers all the types we've registered here.
   result.add genTypeClass(typeClassName(), true, compTypeNodes)

--- a/polymorph/entities.nim
+++ b/polymorph/entities.nim
@@ -52,7 +52,7 @@ proc makeEntityItems*(options: ECSEntityOptions): NimNode =
       of esSeq: genSeq(entityStorageItem)
       of esArray: genArray(maxEntities + 1, entityStorageItem)
       of esPtrArray: nnkPtrTy.newTree(genArray(maxEntities + 1, entityStorageItem))
-    
+
     # Code to initialise entity state.
     entCompInit =
       case options.entityStorageFormat
@@ -98,8 +98,9 @@ proc makeEntityItems*(options: ECSEntityOptions): NimNode =
         entityCounter: int
         # List of spare ids to use, updated when an entity is deleted or added.
         entityRecycler: `recycler`
-        # newEntityId starting at FIRST_ENTITY_ID of 1 avoids 'empty' entityID bugs
+        # newEntityId starting at FIRST_ENTITY_ID of 1 avoids 'empty' entityID bugs.
         nextEntityId: EntityId
+
     proc `initEntityStorageType`(`initParamName`: var `entityStorageIdent`) =
       ## Initialiser for entity state.
       `entCompInit`

--- a/polymorph/runtimeconstruction.nim
+++ b/polymorph/runtimeconstruction.nim
@@ -1,0 +1,347 @@
+
+import macros, private/utils, sharedtypes, tables
+from strutils import toLowerAscii
+
+  
+proc buildConstructionCaseStmt(entity: NimNode, entOpts: ECSEntityOptions, extractOwned: bool): NimNode =
+  # Build a case statement to handle updating linked systems for
+  # each component in the input list.
+  let
+    compIndexInfo = ident "curCompInfo"
+    visited = ident "visited"
+    types = ident "types"
+
+  var
+    compCase = nnkCaseStmt.newTree()
+
+    # Fetch array of component id by list of system indexes.
+    systemsByCompId = compSystems()
+
+  # Select on typeId.
+  compCase.add(quote do: `compIndexInfo`[0].int)
+
+  for typeId in ecsComponentsToBeSealed:
+    let
+      linkedSystems = systemsByCompId[typeId.int]
+      addToSystems = newStmtList()
+    var ofBranch = nnkOfBranch.newTree()
+    ofBranch.add newLit typeId.int
+
+    for sys in linkedSystems:
+      let
+        requiredComps = sysRequirements[sys.int]
+        systemStr = systemNames[sys.int]
+        sysTupleType = ident tupleName(systemStr)
+        sysTupleVar = ident tupleName(systemStr).toLowerAscii
+      var
+        matchList = newSeqOfCap[NimNode](requiredComps.len)
+        sysFields = newStmtList()
+        stateUpdates = newStmtList()
+        assertions = newStmtList()
+      
+      if requiredComps.len > 0:
+
+        # Generate code to check the system is satisfied
+        # and code to add to this system.
+        for comp in requiredComps:
+          let
+            typeStr = tNames[comp.int]
+            typeField = ident typeStr.toLowerAscii
+            instType = ident typeStr.instanceTypeName
+            refType = ident typeStr.refTypeName
+            ownedByThisSystem = componentSystemOwner[comp.int] == sys
+            compId = comp.int
+
+          if comp != typeId:
+            if ownedByThisSystem:
+              # It's a run time error to not specify all the owned components.
+              let caseTypeIdStr = tNames[typeId.int]
+              assertions.add quote do:
+                assert `types`.hasKey(`comp`),
+                  "Cannot construct: Specified owned component \"" & `caseTypeIdStr` &
+                  "\" also needs owned component \"" & `typeStr` & "\""
+            else:
+              # if statement clause fragment.
+              matchList.add quote do:
+                `types`.hasKey(`comp`)
+
+          let source =
+            if comp == typeId: quote do: `compIndexInfo`[1]
+            else: quote do: `types`[`compId`]
+
+          # Assignment of the tuple field for this component.
+          if extractOwned:
+            if ownedByThisSystem:
+              # Owned fields also need their state initialised.
+              stateUpdates.add updateOwnedComponentState(comp, sys)
+              sysFields.add(quote do:
+                `sysTupleVar`.`typeField` = `refType`(`source`[0]).value)
+            else:
+              # We already have the Instance type stored for unowned components.
+              sysFields.add(quote do:
+                `sysTupleVar`.`typeField` = `instType`(`source`[1]))
+          else:
+            if ownedByThisSystem:
+              # Owned fields also need their state initialised.
+              stateUpdates.add updateOwnedComponentState(comp, sys)
+              sysFields.add(quote do:
+                `sysTupleVar`.`typeField` = `instType`(`source`).access)
+            else:
+              # We already have the Instance type stored for unowned components.
+              sysFields.add(quote do:
+                `sysTupleVar`.`typeField` = `instType`(`source`))
+
+      let
+        systemNode = allSystemsNode[sys.int]
+        row = quote do: `systemNode`.high
+        sysOpts = ecsSysOptions[sys.int]
+        updateIndex = entity.updateIndex(sys, row, sysOpts)
+        addToSystem = addSystemTuple(systemNode, sysTupleVar, sysOpts)
+
+        matchCode = quote do:
+          if not `visited`[`sys`.int]:
+            `visited`[`sys`.int] = true
+            `assertions`
+            var `sysTupleVar`: `sysTupleType`
+            `sysTupleVar`.entity = `entity`
+            `sysFields`
+            `addToSystem`
+            `updateIndex`
+            `stateUpdates`
+      
+      if matchList.len > 0:
+        let sysMatchClause = genInfixes(matchList, "and")
+        addToSystems.add(newIfStmt( (sysMatchClause, matchCode) ))
+      else:
+        addToSystems.add matchCode
+  
+    if addToSystems.len > 0:
+      ofBranch.add addToSystems
+      compCase.add ofBranch
+
+  compCase.add nnkElse.newTree(newStmtList(quote do: discard))
+
+proc makeRuntimeConstruction*(entOpts: ECSEntityOptions): NimNode =
+  ## Builds procedures for creating entities from component lists
+  ## at run time.
+  let
+    cList = ident "componentList"
+    construction = ident "construction"
+    master = ident "master"
+    visited = ident "visited"
+    types = ident "types"
+    compIndexInfo = ident "curCompInfo"
+  let
+    maxSys = allSystemsNode.len
+    reference = ident "reference"
+    res = ident "result"
+    addToEnt = addComponentRef(res, reference, entOpts)
+    tcIdent = ident typeClassName()
+    iterVar = ident "i"
+    component = ident "component"
+    compIdx = ident "compIdx"
+    entity = ident "entity"
+    entities = ident "entities"
+    typeId = ident "typeId"
+    callback = ident "callback"
+    constructCase = buildConstructionCaseStmt(res, entOpts, true)
+    cloneCase = buildConstructionCaseStmt(res, entOpts, false)
+    entCompCount = componentRefsLen(entity, entOpts)
+
+    # Assumes components are added in ascending order.
+    lowCompId = ecsComponentsToBeSealed[0].int
+    highCompId = ecsComponentsToBeSealed[^1].int
+    
+  result = quote do:
+    var
+      # Note: As zero is an invalid component, a component count of eg 5 indicates valid indices of 0..5, not 0..4.
+      manualConstruct: array[`lowCompId`..`highCompId`, ConstructorProc]
+      # Post constructors are called after an entity template has been constructed.
+      postConstruct: array[`lowCompId`..`highCompId`, PostConstructorProc]
+      # Clone constructors allow custom handling of components by type when `clone` is called on an entity.
+      cloneConstruct: array[`lowCompId`..`highCompId`, CloneConstructorProc]
+
+    # Do not rely on the order a callback is invoked when constructing templates
+
+    proc registerConstructor*(`typeId`: ComponentTypeId, `callback`: ConstructorProc) = manualConstruct[`typeId`.int] = `callback`
+    template registerConstructor*(t: typedesc[`tcIdent`], `callback`: ConstructorProc) = registerConstructor(t.typeId, `callback`)
+
+    proc registerPostConstructor*(`typeId`: ComponentTypeId, `callback`: PostConstructorProc) = postConstruct[`typeId`.int] = `callback`
+    template registerPostConstructor*(t: typedesc[`tcIdent`], `callback`: PostConstructorProc) = registerPostConstructor(t.typeId, `callback`)
+
+    proc registerCloneConstructor*(`typeId`: ComponentTypeId, `callback`: CloneConstructorProc) = cloneConstruct[`typeId`.int] = `callback`
+    template registerCloneConstructor*(t: typedesc[`tcIdent`], `callback`: CloneConstructorProc) = registerCloneConstructor(t.typeId, `callback`)
+
+    proc construct*(`cList`: ComponentList, `master`: EntityRef = NO_ENTITY_REF): EntityRef =
+      ## Create a runtime entity from a list of components.
+      ## The user may use `registerCallback` to control construction of particular types.
+      ## When called from a `ConstructionList`, `master` is set to the first entity constructed.
+
+      `res` = newEntity()
+      # master defaults to the current entity if nothing specified
+      let
+        masterRef = if `master`.entityId != NO_ENTITY:
+          `master`
+        else:
+          `res`
+      # Build an index to component list, which helps speed things
+      # up when checking systems.
+      var
+        `types`: Table[int, tuple[`component`: Component, `compIdx`: ComponentIndex]]
+        `visited`: array[`maxSys`, bool]
+
+      for compRef in `cList`:
+        assert compRef.typeId != InvalidComponent, "Cannot construct: invalid component type id: " & $compRef.typeId.int
+        assert not `types`.hasKey(compRef.typeId.int), "Cannot construct: Entity has duplicate components for " & $compRef.typeId
+        var `reference`: ComponentRef
+
+        # Index and unowned component generation.
+        caseComponent compRef.typeId:
+          # trigger construction callback if present
+          let cb = manualConstruct[compRef.typeId.int]
+          if cb != nil:
+            # The callback is responsible for adding reference(s) from the source entity.
+            # Callbacks may add multiple sets of components or none at all.
+            let compsAdded = cb(`res`, compRef, masterRef)
+            # We must now include manually added components to the index so
+            # that systems are updated in the second stage below.
+            # It is still possible to add owned components, and their
+            # dependencies will be checked in the second pass.
+
+            # We now have to work out which types have been returned.
+            for comp in compsAdded:
+              assert comp.typeId != InvalidComponent, "Cannot construct: invalid component type id: " & $comp.typeId.int
+              assert not `types`.hasKey(comp.typeId.int), "Cannot construct: Entity has duplicate components for " & $comp.typeId
+              caseComponent comp.typeId:
+                when owningSystemIndex == InvalidSystemIndex:
+                  `reference` = newInstance(componentRefType()(comp).value).toRef
+                else:
+                  # This reference isn't valid until we add the tuple in the second pass.
+                  `reference` = (
+                    componentId(),
+                    owningSystem.count.ComponentIndex,
+                    1.ComponentGeneration
+                  )
+                `addToEnt`
+                `types`.add(comp.typeId.int, (comp, `reference`.index))
+          else:
+            when owningSystemIndex == InvalidSystemIndex:
+              `reference` = newInstance(componentRefType()(compRef).value).toRef            
+            else:
+              # This reference isn't valid until we add the tuple in the second pass.
+              `reference` = (
+                componentId(),
+                owningSystem.count.ComponentIndex,
+                1.ComponentGeneration
+              )
+            `addToEnt`
+            `types`.add(compRef.typeId.int, (compRef, `reference`.index))
+
+      # Update systems.
+      for `compIndexInfo` in `types`.pairs:
+        `constructCase`
+
+    proc construct*(`construction`: ConstructionTemplate): seq[EntityRef] =
+      ## Constructs multiple entities and returns their entity ids.
+      ## The first entity in the list is passed to the others as the "master".
+      ## This same entity is also passed to each individual component's constructor,
+      ## this allows components to have some reference to their construction environment.
+      ## For example, the first entity can contain a physics body component that others may
+      ## reference.
+      ## No other structure is assumed, and the meaning of 'master' is defined by the user.
+      ## Components are constructed in order, calling manual construction code per type,
+      ## then a second parse calls post construction calls with reference to the completed component list.
+      ## This second parse tests for and triggers post construction hooks, which are fed the fully
+      ## constructed entity and it's existing component, along with the rest of the constructed entities
+      ## in this template. This allows fetching components to read initialised values.
+
+      if `construction`.len > 0:
+        result.setLen(`construction`.len)
+        result[0] = `construction`[0].construct(NO_ENTITY_REF)
+
+        for `iterVar` in 1 ..< `construction`.len:
+          result[`iterVar`] = `construction`[`iterVar`].construct(result[0])
+
+        # Re-parse components to check for and activate post construction callbacks.
+        # This post-step allows the user to do any multi-entity work that may be required
+        # such as physics linkage and so on.
+        # You can add/remove components within callbacks here.
+        var `iterVar`: int
+        while `iterVar` < `res`.len:
+          let ent = `res`[`iterVar`]
+          for compRef in entityData(ent.entityId).componentRefs:
+            let tId = compRef.typeId
+            let pc = postConstruct[tId.int]
+            if pc != nil:
+              # Callback passes this entity and the fully constructed result array.
+              pc(ent, compRef, `res`)
+          `iterVar` += 1
+
+    proc toTemplate*(`entity`: EntityRef): seq[Component] =
+      ## Creates a list of components ready to be used for construction.
+      assert `entity`.alive
+      let `entity` = `entity`.entityId
+      let length = `entCompCount`
+      `res` = newSeq[Component](length)
+      for i, compRef in `entity`.componentPairs:
+        caseComponent(compRef.typeId):
+          `res`[i] = componentInstanceType()(compRef.index).makeContainer()
+
+    proc clone*(`entity`: EntityRef): EntityRef =
+      ## Copy an entity's components to a new entity.
+      ## Note that copying objects with pointers/references can have undesirable results.
+      ## For special setup, use `registerCloneConstructor` for the type. This gets passed
+      ## the clone type it would have added. You can then add a modified component or 
+      ## entirely different set of components, or ignore it by not adding anything.
+      assert `entity`.alive, "Cloning a dead entity"
+
+      `res` = newEntity()
+      # Build an index to component list, which helps speed things
+      # up when checking systems.
+      var
+        `types`: Table[int, ComponentIndex]
+        `visited`: array[`maxSys`, bool]
+
+      for compRef in `entity`.components:
+        assert compRef.typeId != InvalidComponent, "Cannot construct: invalid component type id: " & $compRef.typeId.int
+        assert not `types`.hasKey(compRef.typeId.int), "Cannot construct: Entity has duplicate components for " & $compRef.typeId
+        var `reference`: ComponentRef
+
+        # Index and unowned component generation.
+        caseComponent compRef.typeId:
+          # trigger construction callback if present
+          let cb = cloneConstruct[compRef.typeId.int]
+          if cb != nil:
+            # The callback is responsible for adding reference(s) from the source entity.
+            # Callbacks may add multiple sets of components or none at all.
+            let compsAdded = cb(`res`, compRef)
+            # We must now include manually added components to the index so
+            # that systems are updated in the second stage below.
+            # It is still possible to add owned components, and their
+            # dependencies will be checked in the second pass.
+
+            # We now have to work out which types have been returned.
+            for comp in compsAdded:
+              assert comp.typeId != InvalidComponent, "Cannot construct: invalid component type id: " & $comp.typeId.int
+              assert not `types`.hasKey(comp.typeId.int), "Cannot construct: Entity has duplicate components for " & $comp.typeId
+              caseComponent comp.typeId:
+                when owningSystemIndex == InvalidSystemIndex:
+                  `reference` = newInstance(componentRefType()(comp).value).toRef            
+                else:
+                  # This reference isn't valid until we add the tuple in the second pass.
+                  `reference` = compRef
+                `addToEnt`
+                `types`.add(comp.typeId.int, `reference`.index)
+          else:
+            when owningSystemIndex == InvalidSystemIndex:
+              `reference` = newInstance(componentInstanceType()(compRef.index).access).toRef            
+            else:
+              # This reference isn't valid until we add the tuple in the second pass.
+              `reference` = compRef
+            `addToEnt`
+            `types`.add(compRef.typeId.int, `reference`.index)
+            
+      # Update systems.
+      for `compIndexInfo` in `types`.pairs:
+        `cloneCase`
+

--- a/tests/constructandclone.nim
+++ b/tests/constructandclone.nim
@@ -1,0 +1,120 @@
+import polymorph, unittest
+
+template defineConstructAndClone*(entOpts: ECSEntityOptions, compOpts: ECSCompOptions, sysOpts: ECSSysOptions) {.dirty.} =
+  registerComponents(compOpts):
+    type
+      A = object
+        val: int
+      B = object
+        val: float
+      C = object
+        val: string
+      ReplacedFrom = object
+        val: int
+      ReplacedTo = object
+        val: int
+
+  defineSystemOwner("test", [A, B], [A, B], sysOpts)
+  defineSystem("test2", [A, B], sysOpts)
+  defineSystem("test3", [ReplacedTo], sysOpts)
+
+const
+  entOpts = defaultEntityOptions
+  sysOpts = defaultSystemOptions
+  compOpts = defaultComponentOptions
+
+defineConstructAndClone(entOpts, compOpts, sysOpts)
+makeEcs(entOpts)
+commitSystems("run")
+
+proc runConstructAndClone*() =
+
+  suite "Construction":
+    test "Building from template":
+      let templ: ConstructionTemplate = @[
+        @[tmplA(val = 1), tmplB(val = 123.456), tmplC(val = "Hello")]
+      ]
+
+      let ent = templ.construct()
+      check ent[0].hasComponent A
+      check ent[0].hasComponent B
+      check ent[0].hasComponent C
+      let
+        a = ent[0].fetchComponent A
+        b = ent[0].fetchComponent B
+        c = ent[0].fetchComponent C
+      check:
+        a.valid
+        b.valid
+        c.valid
+      check:
+        a.val == 1
+        b.val == 123.456
+        c.val == "Hello"
+      check:
+        sysTest.index.hasKey(ent[0].entityId)
+
+    test "Incomplete owned system build":
+      let templ: ConstructionTemplate = @[
+        @[tmplA(val = 1), tmplC(val = "Hello")]
+      ]
+      expect Exception:
+        let e = templ.construct
+        echo e
+    
+  suite "Cloning":
+    test "Check values":
+      let
+        ent = newEntityWith(A(val: 123), B(val: 123.456), C(val: "Hello"))
+        cloned = ent.clone()
+      check cloned.hasComponent A
+      check cloned.hasComponent B
+      check cloned.hasComponent C
+      check cloned.fetchComponent(A).val == 123
+      check cloned.fetchComponent(B).val == 123.456
+      check cloned.fetchComponent(C).val == "Hello"
+
+  suite "Events":
+
+    registerConstructor ReplacedFrom, proc(entity: EntityRef, component: Component, master: EntityRef): seq[Component] =
+      let rf = ReplacedFromRef(component).value
+      result.add tmplReplacedTo(val = rf.val)
+
+    registerPostConstructor ReplacedTo, proc(entity: EntityRef, component: ComponentRef, entities: var Entities) =
+      let rf = ReplacedToInstance(component.index)
+      rf.val *= 2
+
+    test "Replace component during construction":
+
+      let
+        templ: ConstructionTemplate = @[
+          @[tmplReplacedFrom(val = 123).Component]
+        ]
+        ents = templ.construct()
+
+      check not ents[0].hasComponent(ReplacedFrom)
+      check ents[0].hasComponent ReplacedTo
+      check ents[0].fetchComponent(ReplacedTo).val == 123 * 2
+      check ents[0] in sysTest3
+
+    registerCloneConstructor ReplacedFrom, proc(entity: EntityRef, component: ComponentRef): seq[Component] =
+      let rf = ReplacedFromInstance(component.index)
+      result.add tmplReplacedTo(val = rf.val)
+
+    test "Replace component during cloning":
+      let
+        ent = newEntityWith(A(val: 123), B(val: 123.456), C(val: "Hello"), ReplacedFrom(val: 123))
+        cloned = ent.clone
+      check cloned.hasComponent A
+      check cloned.hasComponent B
+      check cloned.hasComponent C
+      check cloned.hasComponent ReplacedTo
+      check cloned.fetchComponent(A).val == 123
+      check cloned.fetchComponent(B).val == 123.456
+      check cloned.fetchComponent(C).val == "Hello"
+      check cloned.fetchComponent(ReplacedTo).val == 123
+
+
+
+when isMainModule:
+  runConstructAndClone()

--- a/tests/forwardDecl/forwardDeclTest.nim
+++ b/tests/forwardDecl/forwardDeclTest.nim
@@ -8,27 +8,32 @@ proc runForwardDecl* =
       const maxEnts = 4
       var ents = newSeq[EntityRef]()
 
-      for i in 0 ..< maxEnts div 2:
-        ents.add newEntityWith(IncComp(), B())
-        ents.add newEntityWith(IncComp(), B(), C())
+      for i in 0 ..< maxEnts:
+        let v = i + 1
+        if i mod 2 == 0:
+          ents.add newEntityWith(Value(amount: v), AddValue(amount: v))
+        else:
+          ents.add newEntityWith(AddValue(amount: v), IncValue())
 
       runAllSystems()
       
       for i, ent in ents:
         let
-          incComp = ent.fetchComponent IncComp
-          b = ent.fetchComponent B
-          c = ent.fetchComponent C
+          value = ent.fetchComponent Value
+          incValue = ent.fetchComponent IncValue
+          addValue = ent.fetchComponent AddValue
         
-        check incComp.valid
+        check addValue.valid
 
         if i mod 2 == 0:
           check:
-            b.valid
-            not c.valid
+            value.valid
+            not incValue.valid
+            value.amount == (i + 1) * 2 
         else:
           check:
-            b.valid
-            c.valid
-            b.value == 2
-            c.value == 1
+            incValue.valid
+            addValue.amount == (i + 1) + 1
+
+when isMainModule:
+  runForwardDecl()

--- a/tests/forwardDecl/sysdefines.nim
+++ b/tests/forwardDecl/sysdefines.nim
@@ -1,5 +1,5 @@
 import polymorph, types
 
-defineSystem("incB", [IncComp, B])
-defineSystem("addBC", [B, C])
+defineSystem("incValue", [Value, IncValue])
+defineSystem("addValue", [Value, AddValue])
 

--- a/tests/forwardDecl/systems.nim
+++ b/tests/forwardDecl/systems.nim
@@ -1,21 +1,18 @@
 import polymorph, sysdefines, types
 
 # We've already defined this system in `forwardDeclSysDefines` so it's type info is fixed.
-makeSystemBody("incB"):
+makeSystem("incValue", [Value, IncValue]):
   all:
-    item.b.value += 1
+    item.value.amount += 1
 
-# Mixing with inline declared.
-# `makeSystem` adds to systems and so must be invoked before `makeEcs`.
-# If we were declaring all our systems with `defineSystem`,
-# we could put the `makeEcs(maxEnts)` in that module.
-makeSystem("incC", [IncComp, C]):
+# Define a system inline without defineSystem.
+makeSystem("incAmount", [AddValue, IncValue]):
   all:
-    item.c.value += 1
+    item.addValue.amount += 1
 
-makeSystemBody("addBC"):
+makeSystem("addValue", [Value, AddValue]):
   all:
-    item.b.value += item.c.value
+    item.value.amount += item.addValue.amount
 
 makeEcs()
 

--- a/tests/forwardDecl/types.nim
+++ b/tests/forwardDecl/types.nim
@@ -4,10 +4,10 @@ const maxEnts* = 10_000
 
 registerComponents(maxEnts):
   type
-    IncComp* = object
-    B* = object
-      value*: int
-    C* = object
-      value*: int
+    Value* = object
+      amount*: int
+    IncValue* = object
+    AddValue* = object
+      amount*: int
 
 

--- a/tests/onevents.nim
+++ b/tests/onevents.nim
@@ -3,25 +3,21 @@ import polymorph, unittest
 template defineTest*(componentOptions: ECSCompOptions, systemOptions: ECSSysOptions) {.dirty.} =
   registerComponents(componentOptions):
     type
-      Test* = object
+      Test1* = object
         data*: int
-      Test2 = object
+      Test2* = object
         val*: float
 
-  defineSystem("a", [Test], systemOptions)
-  defineSystem("b", [Test], systemOptions)
-  defineSystem("c", [Test], systemOptions)
-  defineSystem("d", [Test, Test2], systemOptions)
+  defineSystem("a", [Test1], systemOptions)
+  defineSystem("b", [Test1], systemOptions)
+  defineSystem("c", [Test1], systemOptions)
+  defineSystemOwner("d", [Test1, Test2], [Test2], systemOptions)
   
-  # TODO: Move storage and access procs to sealing,
-  # allowing us to add hooks for component creation/deletion as well.
-  # This means we have hooks for adding components and creating/freeing components.
-    
   type
     TestTypeKind = enum ttTest, ttTest2
     TestType = object
       case kind: TestTypeKind
-      of ttTest: test: Test
+      of ttTest: test: Test1
       of ttTest2: test2: Test2
 
   import tables, strformat
@@ -30,6 +26,7 @@ template defineTest*(componentOptions: ECSCompOptions, systemOptions: ECSSysOpti
     comp2Adds: int
     systemAdds: Table[string, int]
     systemAddTos: Table[string, int]
+    comp1Intercepts: int
     comp2Intercepts: int
     expected: seq[TestType]
     eventLog: seq[string]
@@ -37,72 +34,83 @@ template defineTest*(componentOptions: ECSCompOptions, systemOptions: ECSSysOpti
   template log(str: string): untyped =
     when displayLog: eventLog.add str
 
-  proc doCheck[T](curComp: T, expectedKind: TestTypeKind) =
+  proc doCheck[T](curComp: T, prefix: string, expectedKind: TestTypeKind) =
     var found: bool
-    for i in countDown(expected.high, 0):
-      if expected[i].kind == expectedKind:
-        found = true
-        when curComp is TestInstance:
-          check curComp.access == expected[i].test
-        elif curComp is Test2Instance:
-          check curComp.access == expected[i].test2
-        else:
-          check 1 == 0, "Unknown type for curComponent"
-        return
-    assert found, "Cannot find expected kind " & $expectedKind & " Expected: " & $expected & " TypeId " & $curComp.typeId.int
-  
-  Test.onAdd:
-    curComponent.doCheck(ttTest)
-    compAdds += 1
-    log &"Entity: {curEntity.entityId.int} adding Test, count: {compAdds}"
-  Test.onRemove:
-    curComponent.doCheck(ttTest)
-    compAdds -= 1
-    log &"Entity: {curEntity.entityId.int} removing Test, count: {compAdds}"
+    test "Event " & prefix & " " & $curComp.type & " expects " & $expectedKind:
+      for i in countDown(expected.high, 0):
+        if expected[i].kind == expectedKind:
+          found = true
+          when curComp is Test1Instance:
+            check curComp.access == expected[i].test
+          elif curComp is Test2Instance:
+            check curComp.access == expected[i].test2
+          elif curComp is Test1:
+            check curComp == expected[i].test
+          elif curComp is Test2:
+            check curComp == expected[i].test2
+          else:
+            checkpoint "Unknown type for curComponent"
+            fail()
+          return
+      if not found:
+        checkpoint "Cannot find expected kind " & $expectedKind & " in expected list: " & $expected & ", curComponent TypeId " & $curComp.typeId.int
+      check found
 
-  Test.onSystemAdd:
-    curComponent.doCheck(ttTest)
+  Test1.onInterceptUpdate:
+    comp1Intercepts += 1
+    log &" Intercepting adding Test1\n Intercept count: {comp1Intercepts}"
+    commit(curValue)
+  Test1.onAdd:
+    curComponent.doCheck("onAdd", ttTest)
+    compAdds += 1
+    log &"Entity: {curEntity.entityId.int} adding Test1, count: {compAdds}"
+  Test1.onRemove:
+    curComponent.doCheck("onRemove", ttTest)
+    compAdds -= 1
+    log &"Entity: {curEntity.entityId.int} removing Test1, count: {compAdds}"
+  
+  Test1.onSystemAdd:
+    curComponent.doCheck("onSystemAdd", ttTest)
     let curVal = systemAdds.getOrDefault(curSystem.name)
     systemAdds[curSystem.name] = curVal + 1
-    log &"Entity: {curEntity.entityId.int} Test adding to system {curSystem.name} count: {systemAdds[curSystem.name]}"
-  Test.onSystemAddTo "a":
-    curComponent.doCheck(ttTest)
+    log &"Entity: {curEntity.entityId.int} Test1 adding to system {curSystem.name} count: {systemAdds[curSystem.name]}"
+  Test1.onSystemAddTo "a":
+    curComponent.doCheck("onSystemAddTo \"a\"", ttTest)
     let curVal = systemAddTos.getOrDefault(curSystem.name)
     systemAddTos[curSystem.name] = curVal + 1
-    log &"Entity: {curEntity.entityId.int} Test adding to specific system {curSystem.name} count: {systemAddTos[curSystem.name]}"
+    log &"Entity: {curEntity.entityId.int} Test1 adding to specific system {curSystem.name} count: {systemAddTos[curSystem.name]}"
   
-  Test.onSystemRemove:
-    curComponent.doCheck(ttTest)
+  Test1.onSystemRemove:
+    curComponent.doCheck("onSystemRemove", ttTest)
     let curVal = systemAdds.getOrDefault(curSystem.name)
     systemAdds[curSystem.name] = curVal - 1
-    log &"Entity: {curEntity.entityId.int} Test removing from system {curSystem.name} count: {systemAdds[curSystem.name]}"
-  Test.onSystemRemoveFrom "a":
-    curComponent.doCheck(ttTest)
+    log &"Entity: {curEntity.entityId.int} Test1 removing from system {curSystem.name} count: {systemAdds[curSystem.name]}"
+  Test1.onSystemRemoveFrom "a":
+    curComponent.doCheck("onSystemRemoveFrom \"a\"", ttTest)
     let curVal = systemAddTos.getOrDefault(curSystem.name)
     systemAddTos[curSystem.name] = curVal - 1
-    log &"Entity: {curEntity.entityId.int} Test removing from specific system {curSystem.name} count: {systemAddTos[curSystem.name]}"
-
+    log &"Entity: {curEntity.entityId.int} Test1 removing from specific system {curSystem.name} count: {systemAddTos[curSystem.name]}"
 
   Test2.onInterceptUpdate:
     comp2Intercepts += 1
     log &" Intercepting adding Test2\n Intercept count: {comp2Intercepts}"
     commit(curValue)
   Test2.onAdd:
-    curComponent.doCheck(ttTest2)
+    curComponent.doCheck("onAdd", ttTest2)
     comp2Adds += 1
     log &"Entity: {curEntity.entityId.int} adding Test2, count: {comp2Adds}"
   Test2.onRemove:
-    curComponent.doCheck(ttTest2)
+    curComponent.doCheck("onRemove", ttTest2)
     comp2Adds -= 1
     log &"Entity: {curEntity.entityId.int} removing Test2, count: {comp2Adds}"
 
   Test2.onSystemAdd:
-    curComponent.doCheck(ttTest2)
+    curComponent.doCheck("onSystemAdd", ttTest2)
     let curVal = systemAdds.getOrDefault(curSystem.name)
     systemAdds[curSystem.name] = curVal + 1
     log &"Entity: {curEntity.entityId.int} Test2 adding to system {curSystem.name} count: {systemAdds[curSystem.name]}"
   Test2.onSystemRemove:
-    curComponent.doCheck(ttTest2)
+    curComponent.doCheck("onSystemRemove", ttTest2)
     let curVal = systemAdds.getOrDefault(curSystem.name)
     systemAdds[curSystem.name] = curVal - 1
     log &"Entity: {curEntity.entityId.int} Test2 removing from system {curSystem.name} count: {systemAdds[curSystem.name]}"
@@ -124,106 +132,126 @@ proc runOnEvents* =
 
   comp2Intercepts = 0
 
-  suite "On<Event> checks":
-    let entCount = 1
-    var
-      testVal: Test
-      otherEntVal = Test(data: 180)
-      test2Val: Test2
-      e1, e2, e3: EntityRef
-      expectedE1, expectedE2, expectedE3: seq[TestType]
-    for i in 0 ..< entCount:
-      # Expecting x2 Test2 instances going through `update`.
-      test "e1 newEntityWith...":
-        
-        testVal = Test(data: 1)
-        expectedE1 = @[TestType(kind: ttTest, test: testVal)]
-        expected = expectedE1
+  proc checkGroups(prefix = "") =
+    forAllSystems:
+      test prefix & ": Check group trimming for system \"" & sys.name & "\"" :
+        var ok = true
+        for i, ite in sys.groups:
+          if not ite.entity.alive:
+            checkpoint "Group idx " & $i & " is dead in system \"" & sys.name & "\" EntityId " & $ite.entity.entityId.int
+            ok = false
+          check ite.entity.alive
+        check ok
 
-        log "NewEntityWith:"
-        e1 = newEntityWith(
-          testVal
-        )
-
-      test "Other entity...":
-        expected = @[TestType(kind: ttTest, test: otherEntVal)]
-        log "NewEntityWith:"
-        otherEnts.add newEntityWith(Test(data: 180))
-
-      test "e2 addComponents...":
-        e2 = newEntity()
-        testVal = Test(data: rand 10000)
-        test2Val = Test2(val: rand 1.0)
-        
-        expectedE2 = @[TestType(kind: ttTest, test: testVal), TestType(kind: ttTest2, test2: test2Val)]
-        expected = expectedE2
-        log "AddComponents:"
-        discard e2.addComponents(testVal, test2Val)
+  let entCount = 1
+  var
+    testVal: Test1
+    otherEntVal = Test1(data: 180)
+    test2Val: Test2
+    e1, e2, e3: EntityRef
+    expectedE1, expectedE2, expectedE3: seq[TestType]
+  for i in 0 ..< entCount:
+    # Expecting x2 Test2 instances going through `update`.
+    suite "e1 newEntityWith...":
       
-      test "e2 deleting...":
-        # Expected should match addComponents.
-        log "Deleting:"
-        e2.delete
+      testVal = Test1(data: 1)
+      expectedE1 = @[TestType(kind: ttTest, test: testVal)]
+      expected = expectedE1
 
-      test "e3 addComponent 1...":
-        e3 = newEntity()
-        testVal = Test(data: 3)
-        expectedE3 = @[TestType(kind: ttTest, test: testVal)]
-        expected = expectedE3
+      log "NewEntityWith:"
+      e1 = newEntityWith(
+        testVal 
+      )
 
-        log "AddComponent Test:"
-        e3.addComponent testVal
-        
-      test "e3 addComponent 2...":
-        test2Val = Test2(val: rand 1.0)
-        # The entity already had Test and so now matches "d", as such
-        # we should expect two system add invocations for Test and Test 2 being placed within "d".  
-        expected = @[TestType(kind: ttTest, test: testVal), TestType(kind: ttTest2, test2: test2Val)]
-        log "AddComponent Test2:"
-        e3.addComponent test2Val
-      
-      test "e3 Removing component...":
-        # This will trigger for both components in the "d" system as well as for each of the other
-        # systems that take Test.
-        expected = @[TestType(kind: ttTest, test: testVal), TestType(kind: ttTest2, test2: test2Val)]
-        log "RemoveComponent:"
-        e3.removeComponent Test
-      
-      test "e1 & e3 delete...":
-        expected = expectedE1
-        log "Delete:"
-        e1.delete
-        expected = @[TestType(kind: ttTest2, test2: test2Val)]
-        e3.delete
-      log "---"
-
-    test "Deleting other ents...":
-      log "Delete other ents:"
+    suite "Other entity...":
       expected = @[TestType(kind: ttTest, test: otherEntVal)]
-      for ent in otherEnts:
-        ent.delete
-    
-    test "Add/remove component events balance":
-      check compAdds == 0
-      check comp2Adds == 0
+      log "NewEntityWith:"
+      otherEnts.add newEntityWith(Test1(data: 180))
 
-    proc balanced(table: Table[string, int]): bool =
-      for pair in table.pairs:
-        if pair[1] != 0:
-          echo "System " & pair[0] & " has non-zero add count: " & $pair[1]
-          return false
-      true
-    test "Add to any system":
-      check systemAdds.balanced
-    test "Add to specific system":
-      check systemAddTos.balanced
+    suite "e2 addComponents...":
+      e2 = newEntity()
+      testVal = Test1(data: rand 10000)
+      test2Val = Test2(val: rand 1.0)
+      
+      expectedE2 = @[TestType(kind: ttTest, test: testVal), TestType(kind: ttTest2, test2: test2Val)]
+      expected = expectedE2
+      log "AddComponents:"
+      discard e2.addComponents(testVal, test2Val)
+    checkGroups("e2 addComponents")
+    suite "e2 deleting...":
+      # Expected should match addComponents.
+      log "Deleting:"
+      e2.delete
+    checkGroups("e2 deleting")
+
+    suite "e3 addComponent 1...":
+      e3 = newEntity()
+      testVal = Test1(data: 3)
+      expectedE3 = @[TestType(kind: ttTest, test: testVal)]
+      expected = expectedE3
+
+      log "AddComponent Test1:"
+      discard e3.addComponent testVal
+      
+    suite "e3 addComponent 2...":
+      test2Val = Test2(val: rand 1.0)
+      # The entity already had Test1 and so now matches "d", as such
+      # we should expect two system add invocations for Test1 and Test1 2 being placed within "d".  
+      expected = @[TestType(kind: ttTest, test: testVal), TestType(kind: ttTest2, test2: test2Val)]
+      log "AddComponent Test2:"
+      discard e3.addComponents test2Val
+    
+    suite "e3 Removing component...":
+      # This will trigger for both components in the "d" system as well as for each of the other
+      # systems that take Test1.
+      expected = @[TestType(kind: ttTest, test: testVal), TestType(kind: ttTest2, test2: test2Val)]
+      log "RemoveComponent:"
+
+      e3.removeComponent Test1
+      
+      # We expect that because Test2 is owned, removing Test1
+      # invalidates Test2's storage so it is also removed.
+      check e3.componentCount == 0
+
+    suite "e1 delete...":
+      expected = expectedE1
+      log "Delete:"
+      e1.delete
+    suite "e3 delete...":
+      expected = @[TestType(kind: ttTest2, test2: test2Val)]
+      e3.delete
+    log "---"
+
+  test "Deleting other ents...":
+    log "Delete other ents:"
+    expected = @[TestType(kind: ttTest, test: otherEntVal)]
+    for ent in otherEnts:
+      ent.delete
+  
+  test "Add/remove component events balance":
+    check compAdds == 0
+    check comp2Adds == 0
+
+  proc balanced(table: Table[string, int]): bool =
+    for pair in table.pairs:
+      if pair[1] != 0:
+        echo "System " & pair[0] & " has non-zero add count: " & $pair[1]
+        return false
+    true
+  test "Add to any system":
+    check systemAdds.balanced
+  test "Add to specific system":
+    check systemAddTos.balanced
+  test "Intercept create unowned:":
+    check comp1Intercepts == entCount * 4
+  test "Intercept create owned:":
     check comp2Intercepts == entCount * 2
   
   when displayLog:
     echo "Log:"
     for item in eventLog: echo item
   echo "Finish."
-
+  flushGenLog()
 
 when isMainModule:
   runOnEvents()

--- a/tests/ownedcomponents.nim
+++ b/tests/ownedcomponents.nim
@@ -1,0 +1,148 @@
+import polymorph
+
+const
+  maxEnts = 1_000_000
+  entOpts = ECSEntityOptions(maxEntities: maxEnts, entityStorageFormat: esArray, componentStorageFormat: csArray, maxComponentsPerEnt: 4)
+  sysOpts = ECSSysOptions(maxEntities: maxEnts, storageFormat: ssArray, indexFormat: sifArray)
+  compOpts = ECSCompOptions(maxComponents: 4, componentStorageFormat: cisArray)
+
+registerComponents(compOpts):
+  type
+    A = object
+      val: int
+    B = object
+      val: int
+    C = object
+      val: int
+    D = object
+      val: int
+
+    E = object
+      val: int
+    F = object
+      val: int
+
+    G = object
+      val: int
+    H = object
+      val: int
+
+defineSystemOwner("fullyOwned", [A, B, C, D], [A, B, C, D], sysOpts)
+defineSystem(     "refToOwned", [A, B, C, D], sysOpts )
+defineSystemOwner("partiallyOwned", [C, D, E, F], [E, F], sysOpts)
+defineSystem(     "unowned", [G, H], sysOpts)
+
+makeSystem("test", [A, B, C, D]):
+  all:
+    item.a.val += item.b.val
+    item.c.val += item.d.val
+
+makeEcs(entOpts)
+commitSystems("run")
+
+import unittest
+
+var ents: seq[EntityRef]
+suite "newEntityWith owned components":
+  test "NewEntityWith correctness":
+    for i in 0..10:
+      let
+        v = i + 1
+        e = newEntityWith(A(val: v), B(val: v), C(val: v), D(val: v))
+      ents.add e
+      check e.hasComponent A
+      check e.hasComponent B
+      check e.hasComponent C
+      check e.hasComponent D
+      check e.fetchComponent(A).val == v
+      check e.fetchComponent(B).val == v
+      check e.fetchComponent(C).val == v
+      check e.fetchComponent(D).val == v
+  test "Incomplete newEntityWith missing A":
+    check not(compiles( newEntityWith(B(), C(), D()) ))
+  test "Incomplete newEntityWith missing B":
+    check not(compiles( newEntityWith(A(), C(), D()) ))
+  test "Incomplete newEntityWith missing C":
+    check not(compiles( newEntityWith(A(), B(), D()) ))
+  test "Incomplete newEntityWith missing D":
+    check not(compiles( newEntityWith(A(), B(), C()) ))
+suite "Incomplete owned components":
+  test "Add components fully owned A":
+    let e = newEntity()
+    ents.add e
+    check not(compiles( e.addComponents(A()) ))
+  test "Add components fully owned B":
+    let e = newEntity()
+    ents.add e
+    check not(compiles( e.addComponents(B()) ))
+  test "Add components fully owned C":
+    let e = newEntity()
+    ents.add e
+    check not(compiles( e.addComponents(C()) ))
+  test "Add components fully owned D":
+    let e = newEntity()
+    ents.add e
+    check not(compiles( e.addComponents(D()) ))
+  test "Add components fully owned A B":
+    let e = newEntity()
+    ents.add e
+    check not(compiles( e.addComponents(A()) B() ))
+  test "Add components fully owned B C":
+    let e = newEntity()
+    ents.add e
+    check not(compiles( e.addComponents(B(), C()) ))
+  test "Add components fully owned C D":
+    let e = newEntity()
+    ents.add e
+    check not(compiles( e.addComponents(C(), D()) ))
+  test "Add components fully owned A B C":
+    let e = newEntity()
+    ents.add e
+    check not(compiles( e.addComponents(A(), B(), C()) ))
+  test "Add components fully owned B C D":
+    let e = newEntity()
+    ents.add e
+    check not(compiles( e.addComponents(B(), C(), D()) ))
+suite "Adding to owned systems":
+  let e = newEntity()
+  ents.add e
+  test "Add components correctness":
+    let
+      r = e.addComponents(A(val: 1), B(val: 2), C(val: 3), D(val: 4))
+    check:
+      r.a.valid
+      r.a.access.val == 1
+    check:
+      r.b.valid
+      r.b.access.val == 2
+    check:
+      r.c.valid
+      r.c.access.val == 3
+    check:
+      r.d.valid
+      r.d.access.val == 4
+
+flushGenLog()
+run()
+echo "Current entity count after tests: ", entityCount()
+ents.deleteAll
+for i in 0 ..< maxEnts:
+  discard newEntityWith(A(val: 1), B(val: 2), C(val: 3), D(val: 4))
+
+echo "Added"
+import times, stats
+var rs: RunningStat
+
+let
+  entTests = 100
+
+for i in 0 ..< entTests:
+  let s = cpuTime()
+  run()
+  let f = cpuTime()
+  rs.push(f - s)
+
+echo "Mean run time for ", maxEnts, " entities over ", entTests, " runs: ", rs.mean
+echo "Run time variance: ", rs.variance
+echo "Finish."
+

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -1,4 +1,4 @@
-import polymorph, basic, forwardDecl/forwardDeclTest as fdcl, onevents
+import polymorph, basic, forwardDecl/forwardDeclTest as fdcl, onevents, constructandclone
 
 const
   compOpts = ECSCompOptions()
@@ -7,6 +7,7 @@ const
 
 runBasic(entOpts, compOpts, sysOpts)
 runForwardDecl()
+runConstructAndClone()
 runOnEvents()
 
 flushGenLog()


### PR DESCRIPTION
* Systems can now "own" individual component types. This means those types are stored within the system group itself rather than as an indirection to a specific storage (only one system may own a particular type). Otherwise owned components should have the same API, with some restrictions on their creation. Owned components are not allowed to exist without their owning system's group being fully satisfied.
* Major restructuring of codegen to accommodate ownership with a shift towards generating later in the sealing process.
* Split construction into a separate module.
* `Component` type is now defined in sharedtypes.
* `addComponents` now used to generate singular `addComponent`.
* Improved basic tests and added extra tests for construction and owned components.