### PR TITLE
Compgen state refactor

### DIFF
--- a/polymorph/entities.nim
+++ b/polymorph/entities.nim
@@ -1,4 +1,4 @@
-import macros, sharedtypes, private/utils
+import macros, sharedtypes, private/[utils, ecsstateinfo]
 
 proc genComponentSet: NimNode =
   ## Generate an enum that covers all of the components seen so far.
@@ -8,7 +8,7 @@ proc genComponentSet: NimNode =
   for tId in ecsComponentsToBeSealed:
     items.add(
       nnkEnumFieldDef.newTree(
-        ident "ce" & tNames[tId.int],
+        ident "ce" & typeInfo.typeName tId,
         newIntLitNode(tId.int)
       )
     )

--- a/polymorph/private/ecsstateinfo.nim
+++ b/polymorph/private/ecsstateinfo.nim
@@ -1,0 +1,115 @@
+import ../sharedtypes, macros, tables
+
+#[
+  This module defines types that store the compile-time collected type info of components and systems.
+]#
+
+type
+  
+  ## Details for generating components.
+  ComponentInfo* = object
+    id*: ComponentTypeId
+    typeName*: string
+    instanceType*: string
+    refType*: string
+    refInitPrefix*: string
+
+    isOwned*: bool
+    systemOwner*: SystemIndex
+    fields*: seq[tuple[fieldNode, typeNode: NimNode]]
+
+    onInitCode*, onFinalisationCode*,
+      onAddToEntCode*, onRemoveFromEntCode*,
+      onAddCallback*, onRemoveCallback*,
+      onAddAnySystemCode*, onRemoveAnySystemCode*,
+      onInterceptValueInitCode*,
+
+      onAddCallbackForwardDecl*,
+      onRemoveCallbackForwardDecl*: NimNode
+    
+    options*: ECSCompOptions
+    
+  ComponentData = seq[ComponentInfo]
+
+  ## Details for generating systems.
+  SystemInfo* = object
+    id*: SystemIndex
+    systemName*: string
+    # Adding to system events
+    onAddToCode*, onRemoveFromCode*: Table[ComponentTypeId, NimNode] # systemAddToCode, systemRemoveFromCode
+
+    requirements*: seq[ComponentTypeId]
+    ownedComponents*: seq[ComponentTypeId]
+    #
+    instantiation*: NimNode
+    definition*: NimNode
+    
+    options*: ECSSysOptions
+
+  SystemData* = seq[SystemInfo]
+
+proc initComponentInfoEvents*(info: var ComponentInfo) =
+  info.systemOwner = InvalidSystemIndex
+  info.onInitCode = newStmtList()
+  info.onFinalisationCode = newStmtList()
+  info.onAddToEntCode = newStmtList()
+  info.onRemoveFromEntCode = newStmtList()
+  info.onAddCallback = newStmtList()
+  info.onRemoveCallback = newStmtList()
+  info.onAddCallbackForwardDecl = newStmtList()
+  info.onRemoveCallbackForwardDecl = newStmtList()
+  info.onInterceptValueInitCode = newStmtList()
+  info.onAddAnySystemCode = newStmtList()
+  info.onRemoveAnySystemCode = newStmtList()
+
+# TODO: Aim to transition component and system info to be handed down
+# rather than globals defined here.
+# The goal is to be able to pass around ECS definitions as meta-types
+# for code generation, and ultimately, read in and generate ECS
+# architecture from files.
+var
+  # All type data.
+  typeInfo* {.compileTime.} = newSeq[ComponentInfo](1)
+  # All system deta.
+  systemInfo* {.compileTime.} = newSeq[SystemInfo]()
+
+# ComponentInfo utils.
+
+proc contains*(cd: ComponentData, typeName: string): bool =
+  for item in cd:
+    if item.typeName == typeName: return true
+
+proc contains*(cd: ComponentData, typeId: ComponentTypeId): bool =
+  for item in cd:
+    if item.id == typeId: return true
+
+proc info*(cd: ComponentData, id: ComponentTypeId): ComponentInfo {.compileTime.} =
+  assert id.int in 0 ..< cd.len, "Invalid type id: " & $id.int
+  cd[id.int]
+
+proc typeName*(cd: ComponentData, id: ComponentTypeId): string {.compileTime.} =
+  cd[id.int].typeName
+
+proc systemOwner*(cd: ComponentData, id: ComponentTypeId): SystemIndex {.compileTime.} =
+  cd[id.int].systemOwner
+
+proc allTypeNames*(cd: ComponentData): string =
+  if cd.len > 1:
+    result &= cd[1].typeName
+    for i in 2 ..< cd.len:
+      result &= ", " & cd[i].typeName
+
+proc isOwned*(cd: ComponentData, typeId: ComponentTypeId): bool =
+  cd[typeId.int].systemOwner != InvalidSystemIndex
+
+# SystemInfo utils.
+
+proc contains*(sd: SystemData, systemName: string): bool =
+  for item in sd:
+    if item.systemName == systemName: return true
+
+proc allSystemNames*(sd: SystemData): string =
+  if sd.len > 0:
+    result &= sd[0].systemName    
+    for i in 1 ..< sd.len:
+      result &= ", " & sd[i].systemName

--- a/polymorph/sharedtypes.nim
+++ b/polymorph/sharedtypes.nim
@@ -71,8 +71,6 @@ type
   ECSSysIndexFormat* = enum sifTable, sifArray, sifAllocatedSeq
   ECSSysTimings* = enum stNone, stRunEvery, stProfiling
   ECSSysOptions* = object
-    ## Gets set automatically. Had to expose as setName can't see this field (compile time proc scope difference?)
-    fName*: string 
     ## Maximum entities this system can hold.
     maxEntities*: int
     ## Underlying storage format for the system groups.
@@ -91,11 +89,6 @@ type
   ComponentUpdatePerfTuple* = tuple[componentType: string, systemsUpdated: int]
   EntityOverflow* = object of Exception
   DuplicateComponent* = object of Exception
-
-proc setName*(sysOpts: var ECSSysOptions, name: string) =
-  sysOpts.fName = name
-
-proc name*(sysOpts: ECSSysOptions): string = sysOpts.fName
 
 const
   defaultMaxEntities* = 10_000

--- a/tests/basic.nim
+++ b/tests/basic.nim
@@ -315,7 +315,8 @@ template runBasic*(entOpts: ECSEntityOptions, compOpts: ECSCompOptions, sysOpts:
         check sysRemoveAndDeleteSelf.deletedCount == expDeletes
         check sysRemoveAndDeleteSelf.removedCount == expRemoves
         ents.deleteAll
-
+  
+  flushGenLog()
   runBasicTests()
 
 when isMainModule:

--- a/tests/constructandclone.nim
+++ b/tests/constructandclone.nim
@@ -113,8 +113,8 @@ proc runConstructAndClone*() =
       check cloned.fetchComponent(B).val == 123.456
       check cloned.fetchComponent(C).val == "Hello"
       check cloned.fetchComponent(ReplacedTo).val == 123
-
-
+  
+  flushGenLog()
 
 when isMainModule:
   runConstructAndClone()

--- a/tests/ownedcomponents.nim
+++ b/tests/ownedcomponents.nim
@@ -145,4 +145,4 @@ for i in 0 ..< entTests:
 echo "Mean run time for ", maxEnts, " entities over ", entTests, " runs: ", rs.mean
 echo "Run time variance: ", rs.variance
 echo "Finish."
-
+flushGenLog()


### PR DESCRIPTION
This PR refactors internal compile-time gathered data to one place:

    ecsstateinfo.nim

ECS definition state is now mostly held by two objects, which contain their associated generation options, type info, requirements, and user code:

* `ComponentInfo`, and
* `SystemInfo`

This change helps to simplify code generation and makes it easier to extend.