### PR TITLE
Fix invalid indentation

### DIFF
--- a/polymorph/sealing.nim
+++ b/polymorph/sealing.nim
@@ -497,6 +497,7 @@ proc makeRuntimeDebugOutput: NimNode =
   let
     res = ident("result")
     entity = ident("entity")
+    strProcName = nnkAccQuoted.newTree(ident("$"))
     totalCount = systemInfo.len
     tsc = ident("totalSystemCount")
     strOp = nnkAccQuoted.newTree(ident "$")
@@ -752,7 +753,6 @@ proc makeRuntimeDebugOutput: NimNode =
             result &= c.allData.dataStr
           else: result &=
             "      <No data>\n"
-  )
 
   genLog "# Runtime debug output:\n", result.repr
 


### PR DESCRIPTION
Commit 8c4d36035f1f9eb9aab4778f30dac167bb7da4d4 appears to have broken compilation on my machine.

Running `git clone https://github.com/rlipsc/polymorph.git && cd polymorph && nim c polymorph.nim` results in the following compilation error:

`polymorph/polymorph/sealing.nim(755, 3) Error: invalid indentation`

This appears to be caused by a [stray closing paren](https://github.com/rlipsc/polymorph/blob/master/polymorph/sealing.nim#L755).
Removing this paren leads to another error:

`polymorph/polymorph/sealing.nim(551, 11) Error: undeclared identifier: 'strProcName'`

Once [this line](https://github.com/rlipsc/polymorph/commit/8c4d36035f1f9eb9aab4778f30dac167bb7da4d4#diff-fae0d5a85c29c91c97a163c2a7aa972a0e35377d7ce5462fd0f72cd9101addbaL482) is re-added, compilation succeeds.

This PR should fix the two errors.

