### PR TITLE
Fix tests failing with `nimble test`

### DIFF
--- a/polymorph.nimble
+++ b/polymorph.nimble
@@ -7,4 +7,4 @@ license       = "Apache License 2.0"
 requires "nim >= 1.0.0"
 
 task test, "Test suite":
-  exec "nim c -r tests/testall"
+  exec "nim c -d:debug -r tests/testall"


### PR DESCRIPTION
Without `-d:debug`, `nimble test` would fail with *"Basic tests must be run in debug mode."*