### PR TITLE
Add Github Actions CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: jiro4989/setup-nim-action@v1
+        with:
+          nim-version: 'stable'
+      - name: Run tests
+        run: |
+          nimble develop
+          nimble test
+          

--- a/polymorph.nimble
+++ b/polymorph.nimble
@@ -7,4 +7,4 @@ license       = "Apache License 2.0"
 requires "nim >= 1.0.0"
 
 task test, "Test suite":
-  exec "nim c -r tests/testall"
+  exec "nim c -d:debug -r tests/testall"


### PR DESCRIPTION
This is a simple CI setup that installs Nim and runs tests every push and pull request.

Note that I had to add `-d:debug` to Nimble, as without it test would fail with *"Basic tests must be run in debug mode."*.