### PR TITLE
Allow removing multiple components at once

### DIFF
--- a/polymorph/components.nim
+++ b/polymorph/components.nim
@@ -35,15 +35,6 @@ proc addComponentTypeId(id: EcsIdentity, typeNameStr: string): ComponentTypeId {
   
   genLog "# Added component type: \"", typeNameStr, "\" = ", $result.int
 
-proc typeStringToId*(id: EcsIdentity, n: string): ComponentTypeId {.compiletime.} =
-  ## Returns an index for a type string, if found.
-  # TODO: String based checks of types with the same name will return the same ComponentTypeId.
-  # Might want to store type trees themselves and match on that.
-  assert(n != "Component", "Not enough type info to create id: Receiving type `Component`, expected sub-class of Component or a registered component type")
-  var r = id.findCompId(n)
-  assert r.int != -1, "Cannot find type \"" & n & "\" in known component types: " & id.commaSeparate(id.allComponentsSeq)
-  r
-
 ## Checks against invalid component (for example uninitialised data).
 ## This does not check to see if the component is alive in the system, only that it is semantically valid.
 ## Used for example to check that fetchComponent has found its value.
@@ -831,6 +822,7 @@ proc genTypeAccess*(id: EcsIdentity): NimNode =
       when component is `allRefCompsTc`:
         const cRange = `identity`.typeIdRange()
         if component.typeId.int notin cRange.a.int .. cRange.b.int:
+          # Attempt to determine the typeId.
           var copy = component
           copy.fTypeId = component.typeId()
           system.add items, copy

--- a/polymorph/sealing.nim
+++ b/polymorph/sealing.nim
@@ -43,7 +43,7 @@ proc makeEntityState(options: ECSEntityOptions): NimNode =
 
   result = quote do:
     # State definition
-    var `ecStateVarIdent`: `storageType`
+    var `ecStateVarIdent`*: `storageType`
     `initEntityStorageType`(`ecStateVarIdent`)
 
     # Quick access to the entity's object without implying a copy
@@ -1003,6 +1003,7 @@ proc makeListSystem(id: EcsIdentity): NimNode =
     innards = newStmtList()
     entIdent = ident "entity"
   innards.add(quote do: `res` = "")
+  
   for sysId in id.unsealedSystems:
     let
       options = id.getOptions sysId
@@ -1263,7 +1264,7 @@ proc sealStateChanges(id: EcsIdentity): NimNode =
   result.add makeDelete(id)
   result.add makeNewEntityWith(id)
   result.add makeAddComponents(id)
-  result.add makeRemoveComponentDirect(id)
+  result.add makeRemoveComponents(id)
 
 proc sealRuntimeDebugging(id: EcsIdentity): NimNode =
   result = newStmtList()
@@ -1475,6 +1476,7 @@ proc makeEcs(id: EcsIdentity, entityOptions: EcsEntityOptions): NimNode =
   ## * Systems are updated when components are added or removed.
   ## 
   ## To create the system execution procedures, use `commitSystems`.
+  
   when defined(ecsLog) and not defined(ecsLogDetails):
     echo "Building ECS \"" & id.string & "\"..."
 
@@ -1699,7 +1701,7 @@ macro commitSystems*(id: static[EcsIdentity], procName: static[string]): untyped
     var outputStr = noBodies[0]
     for i in 1 ..< noBodies.len:
       outputStr &= ", " & noBodies[i]
-    let noBodyStr = "Systems are defined that do not have bodies: " & `outputStr`
+    let noBodyStr = "Systems are defined that don't have bodies: " & `outputStr`
     result.add(quote do:
       {.hint: `noBodyStr`.}
     )

--- a/polymorph/systems.nim
+++ b/polymorph/systems.nim
@@ -542,8 +542,8 @@ proc generateSystem(id: EcsIdentity, name: string, componentTypes: NimNode, opti
       # Check the components given to makeSystem match defineSystem.
       template errMsg =
         error "Components passed to makeSystem \"" & name &
-          "\" [" & componentTypes.repr &
-          "] in conflict with previous definition in defineSystem: [" &
+          "\" " & componentTypes.repr &
+          " in conflict with previous definition in defineSystem: [" &
           id.commaSeparate(expectedTypes) & "]"
       
       if componentTypes.len != expectedTypes.len:


### PR DESCRIPTION
- Removing components now achieves functional parity with adding
  components.
- Like adding, removing multiple components is pared down to one loop
  for efficiency.

Also:

- Exposes the entity states variable.
- Several internal support functions moved to 'utils.nim'.
- Fixes doubled square brackets in the error message for system
  define/body conflicts.