### PR TITLE
Move the  import into logging switch

### DIFF
--- a/src/polymorph/private/utils.nim
+++ b/src/polymorph/private/utils.nim
@@ -1865,11 +1865,11 @@ proc respondToPragma*(node: NimNode, pragmaName: string, actions: NimNode): NimN
 #-------------------------------------------------------------------------
 
 
-import os
 
-const
-  consistencyChecking* = false
-  defaultGenLogFilename* = getProjectPath() / "ecs_code_log.nim"
+const consistencyChecking* = false
+when defined(ecsLogCode):
+  import os
+  const defaultGenLogFilename* = getProjectPath() / "ecs_code_log.nim"
 
 proc genLog*(id: static[EcsIdentity], params: varargs[string]) {.compileTime.} =
   ## Allows macros to generate a log that is then written to file.


### PR DESCRIPTION
Tried to compile polymorph for a micro-controller to see if it would work. Ran into the dreaded `lib/pure/os.nim(63, 10) Error: OS module not ported to your operating system!` error. The `os` module has a when switch on the top-level which checks if the OS is supported. This means that if you simply import that module (even if you never use it, or only use it from behind your own when switches or in macros) it will trigger the error. The solution in this case is to hide the `import os` behind the logging switch since it's never used when logging is not enabled anyways.