### PR TITLE
Fixed compilation on Nim 2.0 & resetEntityStorage() crash

### DIFF
--- a/src/polymorph/private/utils.nim
+++ b/src/polymorph/private/utils.nim
@@ -880,7 +880,7 @@ proc indexTryGet*(sysNode, entIdNode, rowNode: NimNode, idxFmt: ECSSysIndexForma
   of sifTable:
     quote do:
       `rowNode` = `sysNode`.index.getOrDefault(`entIdNode`, -1)
-      `rowNode` >= 0:
+      `rowNode` >= 0
   of sifArray, sifAllocatedSeq:
     quote do:
       let rowData = `sysNode`.index[`entIdNode`.int]

--- a/src/polymorph/statechanges.nim
+++ b/src/polymorph/statechanges.nim
@@ -1190,11 +1190,12 @@ proc makeDelete*(id: EcsIdentity): NimNode =
 
 
     proc resetEntityStorage* =
-      ## This deletes all entities, removes them from associated systems and resets next entity.
-      for i in 0 ..< `storageVar`.nextEntityId.int:
-        let ent = (i.EntityId).makeRef
-        ent.delete
-      `recyclerClear`
-      `storageVar`.nextEntityId = FIRST_ENTITY_ID
-      `storageVar`.entityCounter = 0
+      if entityCount() != 0:
+        ## This deletes all entities, removes them from associated systems and resets next entity.
+        for i in 0 ..< `storageVar`.nextEntityId.int:
+          let ent = (i.EntityId).makeRef
+          ent.delete
+        `recyclerClear`
+        `storageVar`.nextEntityId = FIRST_ENTITY_ID
+        `storageVar`.entityCounter = 0
 

--- a/src/polymorph/statechanges.nim
+++ b/src/polymorph/statechanges.nim
@@ -1190,8 +1190,8 @@ proc makeDelete*(id: EcsIdentity): NimNode =
 
 
     proc resetEntityStorage* =
+      ## This deletes all entities, removes them from associated systems and resets next entity.
       if entityCount() != 0:
-        ## This deletes all entities, removes them from associated systems and resets next entity.
         for i in 0 ..< `storageVar`.nextEntityId.int:
           let ent = (i.EntityId).makeRef
           ent.delete

--- a/tests/testbasic.nim
+++ b/tests/testbasic.nim
@@ -148,6 +148,9 @@ template runBasic*(entOpts: ECSEntityOptions, compOpts: ECSCompOptions, sysOpts:
   proc runBasicTests() =
     suite "Basic operations":
       var ents = newSeq[EntityRef]()
+
+      test "Clear empty storage":
+        resetEntityStorage()
       
       test "New entity":
         let e = newEntity()


### PR DESCRIPTION
- In Nim 2.0, compilation [was failing](https://github.com/Anuken/polymorph/actions/runs/7070448558/job/19247132145#step:4:16) due to an extra `:` in `utils.nim`
- `resetEntityStorage()` crashes when no entities are present; this has been fixed, and a test case added